### PR TITLE
Handel continuous multiperiod mpds

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -67,6 +67,7 @@ class Config(object):
         self.tfdt32_flag = False # Restart every 3 hours make tfdt fit into 32 bits.
         self.cont = False # Continuous update of MPD AST and seg_nr.
         self.periods_per_hour = -1 # If > 0, generates that many periods per hour. If 0, only one offset period.
+        self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
         self.period_offset = -1 # Make one period with an offset compared to ast
         self.scte35_per_minute = 0 # Number of 10s ads per minute. Maximum 3
         self.utc_timing_methods = []
@@ -244,7 +245,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "peroff", "scte35", "utc", "snr")
+                    "periods", "continuous", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -261,6 +262,7 @@ class ConfigProcessor(object):
                'BaseURL' : self.cfg.base_url,
                'startNumber' : self.cfg.availability_start_time_in_s//self.cfg.seg_duration,
                'periodsPerHour' : self.cfg.periods_per_hour,
+               'continuous' : self.cfg.cont_multiperiod,
                'periodOffset' : self.cfg.period_offset,
                'publishTime' : self.cfg.publish_time}
         if self.cfg.availability_end_time:
@@ -302,6 +304,9 @@ class ConfigProcessor(object):
                 cont_update_flag = True
             elif key == "periods": # Make multiple periods
                 cfg.periods_per_hour = int(value)
+            elif key == "continuous": # only valid when it's set to 1 and periods_per_hour is set
+                if int(value) == 1:
+                    cfg.cont_multiperiod = True
             elif key == "peroff": # Set the period offset
                 cfg.period_offset = int(value)
             elif key == "scte35": # Add SCTE-35 ad messages every minute

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -113,7 +113,7 @@ def process_manifest(filename, in_data, now, utc_timing_methods, utc_head_url):
         period_data = generate_default_period_data(in_data, new_data)
     else:
         period_data = generate_multiperiod_data(in_data, new_data, now)
-    mpmod.process(new_data, period_data)
+    mpmod.process(new_data, period_data, in_data['continuous'])
     return mpmod.get_full_xml()
 
 def generate_default_period_data(in_data, new_data):

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -75,11 +75,11 @@ class MpdProcessor(object):
         self.utc_head_url = utc_head_url
         self.root = self.tree.getroot()
 
-    def process(self, data, period_data):
+    def process(self, data, period_data, continuous=False):
         "Top-level call to process the XML."
         mpd = self.root
         self.process_mpd(mpd, data)
-        self.process_mpd_children(mpd, data, period_data)
+        self.process_mpd_children(mpd, data, period_data, continuous)
 
     def process_mpd(self, mpd, data):
         """Process the root element (MPD)"""
@@ -96,7 +96,7 @@ class MpdProcessor(object):
         if mpd.attrib.has_key('mediaPresentationDuration') and not data.has_key('mediaPresentationDuration'):
             del mpd.attrib['mediaPresentationDuration']
 
-    def process_mpd_children(self, mpd, data, period_data):
+    def process_mpd_children(self, mpd, data, period_data, continuous=False):
         """Process the children of the MPD element.
 
         They should be in order ProgramInformation, UTCTiming, BaseURL, Location, Period, Metrics."""
@@ -128,7 +128,7 @@ class MpdProcessor(object):
         for i in range(1, len(period_data)):
             new_period = copy.deepcopy(period)
             mpd.insert(pos+i, new_period)
-        self.update_periods(mpd, period_data, data['periodOffset'] >= 0)
+        self.update_periods(mpd, period_data, data['periodOffset'] >= 0, continuous)
 
     def insert_baseurl(self, mpd, pos, new_baseurl):
         "Create and insert a new <BaseURL> element."
@@ -141,7 +141,7 @@ class MpdProcessor(object):
         "Modify the text of an existing BaseURL"
         baseurl_elem.text = new_baseurl
 
-    def update_periods(self, mpd, period_data, offset_at_period_level=False):
+    def update_periods(self, mpd, period_data, offset_at_period_level=False, continuous=False):
         "Update periods to provide appropriate values."
 
         def set_attribs(elem, keys, data):
@@ -172,6 +172,7 @@ class MpdProcessor(object):
             return self.create_descriptor_elem("InbandEventStream", scte35.SCHEME_ID_URI, value=str(scte35.PID))
 
         periods = mpd.findall(add_ns('Period'))
+        last_period_id = '-1'
         for (period, pdata) in zip(periods, period_data):
             set_attribs(period, ('id', 'start'), pdata)
             segmenttemplate_attribs = ['startNumber']
@@ -183,16 +184,22 @@ class MpdProcessor(object):
                     segmenttemplate_attribs.append('presentationTimeOffset')
             adaptation_sets = period.findall(add_ns('AdaptationSet'))
             for ad_set in adaptation_sets:
+                ad_pos = 0
                 content_type = ad_set.get('contentType')
                 if content_type == 'video' and self.scte35_present:
                     scte35_elem = create_inband_scte35stream_elem()
                     ad_set.insert(0, scte35_elem)
+                    ad_pos += 1
+                if continuous and last_period_id != '-1':
+                    supplementalprop_elem = self.create_descriptor_elem("SupplementalProperty", \
+                    "urn:mpeg:dash:period_continuity:2014", last_period_id)
+                    ad_set.insert(ad_pos, supplementalprop_elem)
                 seg_templates = ad_set.findall(add_ns('SegmentTemplate'))
                 for seg_template in seg_templates:
                     set_attribs(seg_template, segmenttemplate_attribs, pdata)
                     if pdata.get('startNumber') == '-1': # Default to 1
                         remove_attribs(seg_template, ['startNumber'])
-
+            last_period_id = pdata.get('id')
 
     def create_descriptor_elem(self, name, scheme_id_uri, value=None, elem_id=None):
         "Create an element of DescriptorType."

--- a/dashlivesim/tests/test_dash_proxy.py
+++ b/dashlivesim/tests/test_dash_proxy.py
@@ -144,6 +144,16 @@ class TestMediaSegments(unittest.TestCase):
         periodPositions = findAllIndexes("<Period", d)
         self.assertEqual(len(periodPositions), 3)
 
+    def testContinuous(self):
+        testOutputFile = "ContMultiperiod.mpd"
+        rm_outfile(testOutputFile)
+        urlParts = ['pdash', 'continuous_1', 'periods_10', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=3602)
+        d = dp.handle_request()
+        write_data_to_outfile(d, testOutputFile)
+        periodPositions = findAllIndexes("urn:mpeg:dash:period_continuity:2014", d)
+        self.assertGreater(len(periodPositions), 1)
+
     def testUtcTiming(self):
         "Test that direct and head works."
         urlParts = ['pdash', 'utc_direct-head', 'testpic', 'Manifest.mpd']


### PR DESCRIPTION
Config: add /continuous_1/ in the URL, please use it together with /periods_xx/.

Add test for this function. The code passed all tests.

The Pylint I'm using (v1.4.4) always reports undefined variable errors, which should be false positive. Therefore, I cannot get 10.0 for any code. What I tried was to compare its report before and after my changes. 

For dashlivesim/dashlib/:
before:
+-------------------+------------+
|message id         |occurrences |
+===================+============+
|undefined-variable |1832        |
+-------------------+------------+
|locally-disabled   |20          |
+-------------------+------------+
|bad-option-value   |8           |
+-------------------+------------+
|duplicate-code     |2           |
+-------------------+------------+

after:
+-------------------+------------+
|message id         |occurrences |
+===================+============+
|undefined-variable |1848        |
+-------------------+------------+
|locally-disabled   |20          |
+-------------------+------------+
|bad-option-value   |8           |
+-------------------+------------+
|duplicate-code     |2           |
+-------------------+------------+

For dashlivesim/tests/test_dash_proxy.py
before:
+-----------------------+------------+
|message id             |occurrences |
+=======================+============+
|undefined-variable     |184         |
+-----------------------+------------+
|unused-wildcard-import |8           |
+-----------------------+------------+
|unused-import          |2           |
+-----------------------+------------+
|bad-whitespace         |2           |
+-----------------------+------------+
|missing-docstring      |1           |
+-----------------------+------------+
|line-too-long          |1           |
+-----------------------+------------+

after:
+-----------------------+------------+
|message id             |occurrences |
+=======================+============+
|undefined-variable     |192         |
+-----------------------+------------+
|unused-wildcard-import |8           |
+-----------------------+------------+
|unused-import          |2           |
+-----------------------+------------+
|bad-whitespace         |2           |
+-----------------------+------------+
|missing-docstring      |1           |
+-----------------------+------------+
|line-too-long          |1           |
+-----------------------+------------+

So I think my modification didn't introduce any extra errors except for a few more false positive "undefined variables". 