### PR TITLE
add function for multiple base URLs with specific pattern

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -68,6 +68,7 @@ class Config(object):
         self.cont = False # Continuous update of MPD AST and seg_nr.
         self.periods_per_hour = -1 # If > 0, generates that many periods per hour. If 0, only one offset period.
         self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
+        self.multi_url = [] # If not empty, give multiple URLs in the BaseURL element
         self.period_offset = -1 # Make one period with an offset compared to ast
         self.scte35_per_minute = 0 # Number of 10s ads per minute. Maximum 3
         self.utc_timing_methods = []
@@ -245,7 +246,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "continuous", "peroff", "scte35", "utc", "snr")
+                    "periods", "continuous", "baseurl", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -263,6 +264,7 @@ class ConfigProcessor(object):
                'startNumber' : self.cfg.availability_start_time_in_s//self.cfg.seg_duration,
                'periodsPerHour' : self.cfg.periods_per_hour,
                'continuous' : self.cfg.cont_multiperiod,
+               'urls' : self.cfg.multi_url,
                'periodOffset' : self.cfg.period_offset,
                'publishTime' : self.cfg.publish_time}
         if self.cfg.availability_end_time:
@@ -304,9 +306,11 @@ class ConfigProcessor(object):
                 cont_update_flag = True
             elif key == "periods": # Make multiple periods
                 cfg.periods_per_hour = int(value)
-            elif key == "continuous": # only valid when it's set to 1 and periods_per_hour is set
+            elif key == "continuous": # Only valid when it's set to 1 and periods_per_hour is set
                 if int(value) == 1:
                     cfg.cont_multiperiod = True
+            elif key == "baseurl": # Use multiple URLs, put all the configuration strings in multi_url
+                cfg.multi_url.append(value)
             elif key == "peroff": # Set the period offset
                 cfg.period_offset = int(value)
             elif key == "scte35": # Add SCTE-35 ad messages every minute

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -63,7 +63,7 @@ For infinite content, the default is startNumber = 0, availabilityStartTime = 19
 #  POSSIBILITY OF SUCH DAMAGE.
 
 from os.path import splitext, join
-
+from math import ceil
 from .initsegmentfilter import InitLiveFilter
 from .mediasegmentfilter import MediaSegmentFilter
 from . import segmentmuxer
@@ -102,6 +102,7 @@ def process_manifest(filename, in_data, now, utc_timing_methods, utc_head_url):
                 'duration' : '%d' % in_data['segDuration'],
                 'maxSegmentDuration' : 'PT%dS' % in_data['segDuration'],
                 'BaseURL' : '%s' % in_data['BaseURL'],
+                'urls' : in_data['urls'],
                 'periodOffset' : in_data['periodOffset'],
                 'presentationTimeOffset' : 0}
     if in_data.has_key('availabilityEndTime'):
@@ -210,7 +211,37 @@ class DashProvider(object):
                 diff = self.now_float - (cfg.availability_end_time + EXTRA_TIME_AFTER_END_IN_S)
                 response = self.error_response("Request for %s after AET. %.1fs too late" % (cfg.filename, diff))
             else:
-                response = self.process_media_segment(cfg, self.now_float)
+                if len(self.url_parts) > 4: #possible baseurl info
+                    url_info = self.url_parts[-4].split("_")
+                    if url_info[0] == "baseurl":
+                        a = url_info[1]
+                        b = url_info[2]
+                        dur1 = int(a[1:])
+                        dur2 = int(b[1:])
+                        if a[0] == 'u' and b[0] == 'd': #parse server up or down information
+                            num_loop = ceil(60.0/(float(dur1+dur2)))
+                            for i in range(0, int(num_loop)):
+                                if self.now % 60 > i*(dur1+dur2)+dur1 and self.now % 60 <= (i+1)*(dur1+dur2):
+                                    print "server down time"
+                                    print self.now
+                                    print i
+                                    response = self.error_response("server down time %d" % (self.now))
+                                else:
+                                    response = self.process_media_segment(cfg, self.now_float)
+                        elif a[0] == 'd' and b[0] == 'u':
+                            num_loop = ceil(60.0/(float(dur1+dur2)))
+                            for i in range(0, int(num_loop)):
+                                if self.now % 60 > i*(dur1+dur2) and self.now % 60 <= i*(dur1+dur2)+dur1:
+                                    print "server down time"
+                                    print self.now
+                                    print i
+                                    response = self.error_response("server down time %d" % (self.now))
+                                else:
+                                    response = self.process_media_segment(cfg, self.now_float)
+                    else:
+                        response = self.process_media_segment(cfg, self.now_float)
+                else:
+                    response = self.process_media_segment(cfg, self.now_float)
         else:
             response = "Unknown file extension: %s" % cfg.ext
         return response

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -211,33 +211,28 @@ class DashProvider(object):
                 diff = self.now_float - (cfg.availability_end_time + EXTRA_TIME_AFTER_END_IN_S)
                 response = self.error_response("Request for %s after AET. %.1fs too late" % (cfg.filename, diff))
             else:
-                if len(self.url_parts) > 4: #possible baseurl info
-                    url_info = self.url_parts[-4].split("_")
-                    if url_info[0] == "baseurl":
-                        a = url_info[1]
-                        b = url_info[2]
-                        dur1 = int(a[1:])
-                        dur2 = int(b[1:])
-                        if a[0] == 'u' and b[0] == 'd': #parse server up or down information
-                            num_loop = ceil(60.0/(float(dur1+dur2)))
-                            for i in range(0, int(num_loop)):
-                                if self.now % 60 > i*(dur1+dur2)+dur1 and self.now % 60 <= (i+1)*(dur1+dur2):
-                                    print "server down time"
-                                    print self.now
-                                    print i
-                                    response = self.error_response("server down time %d" % (self.now))
-                                else:
-                                    response = self.process_media_segment(cfg, self.now_float)
-                        elif a[0] == 'd' and b[0] == 'u':
-                            num_loop = ceil(60.0/(float(dur1+dur2)))
-                            for i in range(0, int(num_loop)):
-                                if self.now % 60 > i*(dur1+dur2) and self.now % 60 <= i*(dur1+dur2)+dur1:
-                                    print "server down time"
-                                    print self.now
-                                    print i
-                                    response = self.error_response("server down time %d" % (self.now))
-                                else:
-                                    response = self.process_media_segment(cfg, self.now_float)
+                if  len(cfg.multi_url) == 1:#baseurl info
+                    url_info = cfg.multi_url[0].split("_")
+                    a = url_info[0]
+                    b = url_info[1]
+                    dur1 = int(a[1:])
+                    dur2 = int(b[1:])
+                    if a[0] == 'u' and b[0] == 'd': #parse server up or down information
+                        num_loop = ceil(60.0/(float(dur1+dur2)))
+                        for i in range(0, int(num_loop)):
+                            if self.now % 60 > i*(dur1+dur2)+dur1 and self.now % 60 <= (i+1)*(dur1+dur2):
+                                response = self.error_response("server down time %d" % (self.now))
+                                break
+                            else:
+                                response = self.process_media_segment(cfg, self.now_float)
+                    elif a[0] == 'd' and b[0] == 'u':
+                        num_loop = ceil(60.0/(float(dur1+dur2)))
+                        for i in range(0, int(num_loop)):
+                            if self.now % 60 > i*(dur1+dur2) and self.now % 60 <= i*(dur1+dur2)+dur1:
+                                response = self.error_response("server down time %d" % (self.now))
+                                break
+                            else:
+                                response = self.process_media_segment(cfg, self.now_float)
                     else:
                         response = self.process_media_segment(cfg, self.now_float)
                 else:

--- a/dashlivesim/tests/test_dash_proxy.py
+++ b/dashlivesim/tests/test_dash_proxy.py
@@ -188,12 +188,12 @@ class TestMorePathLevels(unittest.TestCase):
         dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=0)
         d = dp.handle_request()
         write_data_to_outfile(d, testOutputFile)
-        numBaseURL = findAllIndexes("<BaseURL>", d)
-        str1 = findAllIndexes("baseurl_u40_d20", d)
-        str2 = findAllIndexes("baseurl_u40_d20", d)
-        self.assertEqual(len(numBaseURL), 2)
-        self.assertEqual(len(str1), 1)
-        self.assertEqual(len(str2), 1)
+        indexesBaseURL = findAllIndexes("<BaseURL>", d)
+        indexes1 = findAllIndexes("baseurl_u40_d20", d)
+        indexes2 = findAllIndexes("baseurl_d40_u20", d)
+        self.assertEqual(len(indexesBaseURL), 2)
+        self.assertEqual(len(indexes1), 1)
+        self.assertEqual(len(indexes2), 1)
         
     def testInit(self):
         urlParts = ['pdash', 'testpic', 'en', 'A1', 'init.mp4']

--- a/dashlivesim/tests/test_dash_proxy.py
+++ b/dashlivesim/tests/test_dash_proxy.py
@@ -181,6 +181,20 @@ class TestMorePathLevels(unittest.TestCase):
         d = dp.handle_request()
         self.assertGreater(d.find("<BaseURL>http://streamtest.eu/pdash/testpic/</BaseURL>"), 0)
 
+    def testMultiURL(self):
+        testOutputFile = "MultiURL.mpd"
+        rm_outfile(testOutputFile)
+        urlParts = ['pdash', 'baseurl_u40_d20', 'baseurl_d40_u20', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=0)
+        d = dp.handle_request()
+        write_data_to_outfile(d, testOutputFile)
+        numBaseURL = findAllIndexes("<BaseURL>", d)
+        str1 = findAllIndexes("baseurl_u40_d20", d)
+        str2 = findAllIndexes("baseurl_u40_d20", d)
+        self.assertEqual(len(numBaseURL), 2)
+        self.assertEqual(len(str1), 1)
+        self.assertEqual(len(str2), 1)
+        
     def testInit(self):
         urlParts = ['pdash', 'testpic', 'en', 'A1', 'init.mp4']
         dp = dash_proxy.DashProvider("127.0.0.1", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=0)


### PR DESCRIPTION
Syntax: add /baseurl_u()_d()/ or /baseurl_d()_u()/ to the URL to request mpd files. Please replace "()" with an integer. "u" stands for up and "d" for down. In every minute, the server would be switched up or down according to the pattern.

e.g. http://localhost/livesim/baseurl_u10_d20/baseurl_d10_u20/periods_10/testpic_2s/Manifest.mpd. 
In the mpd file, there should be two entries: <BaseURL>http://localhost/livesim/periods_10/baseurl_u10_d20/testpic_2s/</BaseURL> and <BaseURL>http://localhost/livesim/periods_10/baseurl_d10_u20/testpic_2s/</BaseURL>.
The first server should work for 10 seconds and then give a 404 error. After another 20 seconds, the server should work again. The second server works the other way around.

The current reference Dash client/player doesn't support automatically choosing and switching between URLs, as well as resuming playback after the server is up (after it's down for some time), so the test is done separated for different URLs, e.g. http://localhost/livesim/baseurl_u10_d20/testpic_2s/Manifest.mpd, http://localhost/livesim/baseurl_u10_d20/baseurl_d0_u20/testpic_2s/Manifest.mpd, http://localhost/livesim/baseurl_d10_u0/testpic_2s/Manifest.mpd etc. Also the mpd file is checked.