### PR TITLE
Xlink functionality for the dash-live-source-simulator

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -67,6 +67,7 @@ class Config(object):
         self.tfdt32_flag = False # Restart every 3 hours make tfdt fit into 32 bits.
         self.cont = False # Continuous update of MPD AST and seg_nr.
         self.periods_per_hour = -1 # If > 0, generates that many periods per hour. If 0, only one offset period.
+        self.xlink_periods_per_hour = -1 # Number of periods per hour that are accessed via xlink.
         self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
         self.multi_url = [] # If not empty, give multiple URLs in the BaseURL element
         self.period_offset = -1 # Make one period with an offset compared to ast
@@ -246,7 +247,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "continuous", "baseurl", "peroff", "scte35", "utc", "snr")
+                    "periods", "xlink", "continuous", "baseurl", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -263,6 +264,7 @@ class ConfigProcessor(object):
                'BaseURL' : self.cfg.base_url,
                'startNumber' : self.cfg.availability_start_time_in_s//self.cfg.seg_duration,
                'periodsPerHour' : self.cfg.periods_per_hour,
+               'xlinkPeriodsPerHour' : self.cfg.xlink_periods_per_hour,
                'continuous' : self.cfg.cont_multiperiod,
                'urls' : self.cfg.multi_url,
                'periodOffset' : self.cfg.period_offset,
@@ -306,6 +308,8 @@ class ConfigProcessor(object):
                 cont_update_flag = True
             elif key == "periods": # Make multiple periods
                 cfg.periods_per_hour = int(value)
+            elif key == "xlink": # Make periods access via xlink.
+                cfg.xlink_periods_per_hour = int(value)
             elif key == "continuous": # Only valid when it's set to 1 and periods_per_hour is set
                 if int(value) == 1:
                     cfg.cont_multiperiod = True

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -64,13 +64,14 @@ For infinite content, the default is startNumber = 0, availabilityStartTime = 19
 
 from os.path import splitext, join
 from math import ceil
+from re import findall
 from .initsegmentfilter import InitLiveFilter
 from .mediasegmentfilter import MediaSegmentFilter
 from . import segmentmuxer
 from . import mpdprocessor
 from .timeformatconversions import make_timestamp, seconds_to_iso_duration
 from .configprocessor import ConfigProcessor
-from re import findall
+
 
 SECS_IN_DAY = 24*3600
 DEFAULT_MINIMUM_UPDATE_PERIOD = "P100Y"
@@ -129,10 +130,10 @@ def generate_default_period_data(in_data, new_data):
     return [data]
 
 def generate_multiperiod_data(in_data, new_data, now):
-    "Generate an array of period data depending on current time (now). 0 gives one period with start offset."
-    #pylint: disable=too-many-locals
+    " Generate an array of period data depending on current time (now). 0 gives one period with start offset."
+    # pylint: disable=too-many-locals
     nr_periods_per_hour = min(in_data['periodsPerHour'], 60)
-    if not nr_periods_per_hour in (0, 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60):
+    if nr_periods_per_hour not in (0, 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60):
         raise Exception("Bad nr of periods per hour %d" % nr_periods_per_hour)
     seg_dur = in_data['segDuration']
     period_data = []
@@ -158,31 +159,42 @@ def generate_multiperiod_data(in_data, new_data, now):
     return period_data
 
 def generate_response_with_xlink(response, cfg, filename, nr_periods_per_hour, nr_xlink_periods_per_hour):
-    # Convert the normally created response into a response which has xlinks.
-    # This functions has two functionlaties : 1.For MPD and 2.For PERIOD.
-    # 1. When the normally created .mpd file is fed to this function, it removes periods and inserts xlink for the corresponding
-    # periods at that place.
-    # 2. When the xlink period is accessed, it extracts the corresponding period from .mpd file this function, adds some information and returns the appropriate .xml document to the java client.
+    "Convert the normally created response into a response which has xlinks"
+    # This functions has two functionality : 1.For MPD and 2.For PERIOD.
+    # 1. When the normally created .mpd file is fed to this function, it removes periods and inserts xlink for the
+    # corresponding periods at that place.
+    # 2. When the xlink period is accessed, it extracts the corresponding period from .mpd file this function generates,
+    # adds some information and returns the appropriate .xml document to the java client.
     if cfg == ".mpd":
-        period_id_all = findall('Period id="([^"]*)"', response)  # Find all period ids in the response file.
-        one_xlinks_for_how_many_periods =  nr_periods_per_hour/nr_xlink_periods_per_hour
-        period_id_xlinks = [x for x in period_id_all if int(x[1:]) % one_xlinks_for_how_many_periods == 0] # Periods that will be replaced with links.
+        period_id_all = findall('Period id="([^"]*)"', response)
+        # Find all period ids in the response file.
+        one_xlinks_for_how_many_periods = nr_periods_per_hour/nr_xlink_periods_per_hour
+        period_id_xlinks = [x for x in period_id_all if int(x[1:]) % one_xlinks_for_how_many_periods == 0]
+        # Periods that will be replaced with links.
         base_url = findall('<BaseURL>([^"]*)</BaseURL>', response)
-        for period_id in period_id_xlinks:  # Start replacing only if this condition is met.
-            start_pos_period = response.find(period_id)-12  # Find the position in the string file of the period that has be replaced
-            end_pos_period   = response.find("</Period>",start_pos_period)+9  # End position of the corresponding period.
+        for period_id in period_id_xlinks:
+            # Start replacing only if this condition is met.
+            start_pos_period = response.find(period_id)-12
+            # Find the position in the string file of the period that has be replaced
+            end_pos_period = response.find("</Period>", start_pos_period)+9
+            # End position of the corresponding period.
             original_period = response[start_pos_period:end_pos_period]
-            xlink_period = '<Period xlink:href="%s%s+%s.period" xlink:actuate="onLoad" xmlns:xlink="http://www.w3.org/1999/xlink"></Period>' %(base_url[0],filename,period_id)
+            xlink_period = '<Period xlink:href="%s%s+%s.period" xlink:actuate="onLoad" ' \
+                           'xmlns:xlink="http://www.w3.org/1999/xlink"></Period>' %(base_url[0], filename, period_id)
             response = response.replace(original_period, xlink_period)
     else:
-        # Start manipulating the original period so that it looks like .period in static xlink file.
-        filename = filename.split('+')[1] # Second part of string has the period id.
+        # This will be done when ".period" file is being requested
+        # Start manipulating the original period so that it looks like .period in the static xlink file.
+        filename = filename.split('+')[1]
+        # Second part of string has the period id.
         start_pos_xmlns = response.find("xmlns=")
-        end_pos_xmlns = response.find('"',start_pos_xmlns+7)+1
-        start_pos_period = response.find(filename[:-7])-12 # Find the position in the string file of the period that has be replaced
-        end_pos_period   = response.find("</Period>",start_pos_period)+9 # End position of the corresponding period.
+        end_pos_xmlns = response.find('"', start_pos_xmlns+7)+1
+        start_pos_period = response.find(filename[:-7])-12
+        # Find the position in the string file of the period that has be replaced.
+        end_pos_period = response.find("</Period>", start_pos_period)+9
+        # End position of the corresponding period.
         original_period = response[start_pos_period:end_pos_period]
-        original_period = original_period.replace('">','" ' + response[start_pos_xmlns:end_pos_xmlns] + '>',1)
+        original_period = original_period.replace('">', '" ' + response[start_pos_xmlns:end_pos_xmlns] + '>', 1)
         xml_intro = '<?xml version="1.0" encoding="utf-8"?>\n'
         response = xml_intro + original_period
     return response
@@ -193,7 +205,7 @@ class DashProvider(object):
 
     def __init__(self, host_name, url_parts, url_args, vod_conf_dir, content_dir, now=None, req=None, is_https=0):
         protocol = is_https and "https" or "http"
-        self.base_url = "%s://%s/%s/" % (protocol, host_name, url_parts[0]) # The start. Adding other parts later.
+        self.base_url = "%s://%s/%s/" % (protocol, host_name, url_parts[0])  # The start. Adding other parts later.
         self.utc_head_url = "%s://%s/%s" % (protocol, host_name, UTC_HEAD_PATH)
         self.url_parts = url_parts[1:]
         self.url_args = url_args
@@ -229,15 +241,20 @@ class DashProvider(object):
             mpd_input_data = cfg_processor.get_mpd_data()
             response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
             nr_xlink_periods_per_hour = min(mpd_input_data['xlinkPeriodsPerHour'], 60)
-            if nr_xlink_periods_per_hour > 0: # -1 is the default value, which means no xlink are created.
-                nr_periods_per_hour = min(mpd_input_data['periodsPerHour'], 60) # See exception description for explanation.
-                one_xlinks_for_how_many_periods =  float(nr_periods_per_hour)/nr_xlink_periods_per_hour
+            if nr_xlink_periods_per_hour > 0:
+                # -1 is the default value, which means no xlink are created.
+                nr_periods_per_hour = min(mpd_input_data['periodsPerHour'], 60)
+                # See exception description for explanation.
+                one_xlinks_for_how_many_periods = float(nr_periods_per_hour)/nr_xlink_periods_per_hour
                 if nr_periods_per_hour == -1:
                     response = self.error_response("Xlinks can only be created for a multiperiod service.")
-                elif one_xlinks_for_how_many_periods != int(one_xlinks_for_how_many_periods): # The same kind of exception that was applied for periods.
-                    response = self.error_response("(Number of periods per hour/ Number of xlinks per hour) should be an integer.")
+                elif one_xlinks_for_how_many_periods != int(one_xlinks_for_how_many_periods):
+                    # The same kind of exception that was applied for periods.
+                    response = self.error_response("(Number of periods per hour/ Number of xlinks per hour) "
+                                                   "should be an integer.")
                 else:
-                    response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour, nr_xlink_periods_per_hour)
+                    response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour,
+                                                            nr_xlink_periods_per_hour)
         elif cfg.ext == ".mp4":
             if self.now < cfg.availability_start_time_in_s - cfg.init_seg_avail_offset:
                 diff = (cfg.availability_start_time_in_s - cfg.init_seg_avail_offset) - self.now_float
@@ -257,7 +274,7 @@ class DashProvider(object):
             else:
                 response = self.process_media_segment(cfg, self.now_float)
                 if len(cfg.multi_url) == 1: # There is one specific baseURL with losses specified
-                    a,b = cfg.multi_url[0].split("_")
+                    a, b = cfg.multi_url[0].split("_")
                     dur1 = int(a[1:])
                     dur2 = int(b[1:])
                     total_dur = dur1 + dur2

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -70,6 +70,7 @@ from . import segmentmuxer
 from . import mpdprocessor
 from .timeformatconversions import make_timestamp, seconds_to_iso_duration
 from .configprocessor import ConfigProcessor
+from re import findall
 
 SECS_IN_DAY = 24*3600
 DEFAULT_MINIMUM_UPDATE_PERIOD = "P100Y"
@@ -156,6 +157,35 @@ def generate_multiperiod_data(in_data, new_data, now):
         period_data.append(data)
     return period_data
 
+def generate_response_with_xlink(response, cfg, filename, nr_periods_per_hour, nr_xlink_periods_per_hour):
+    # Convert the normally created response into a response which has xlinks.
+    # This functions has two functionlaties : 1.For MPD and 2.For PERIOD.
+    # 1. When the normally created .mpd file is fed to this function, it removes periods and inserts xlink for the corresponding
+    # periods at that place.
+    # 2. When the xlink period is accessed, it extracts the corresponding period from .mpd file this function, adds some information and returns the appropriate .xml document to the java client.
+    if cfg == ".mpd":
+        period_id_all = findall('Period id="([^"]*)"', response)  # Find all period ids in the response file.
+        one_xlinks_for_how_many_periods =  nr_periods_per_hour/nr_xlink_periods_per_hour
+        period_id_xlinks = [x for x in period_id_all if int(x[1:]) % one_xlinks_for_how_many_periods == 0] # Periods that will be replaced with links.
+        base_url = findall('<BaseURL>([^"]*)</BaseURL>', response)
+        for period_id in period_id_xlinks:  # Start replacing only if this condition is met.
+            start_pos_period = response.find(period_id)-12  # Find the position in the string file of the period that has be replaced
+            end_pos_period   = response.find("</Period>",start_pos_period)+9  # End position of the corresponding period.
+            original_period = response[start_pos_period:end_pos_period]
+            xlink_period = '<Period xlink:href="%s%s+%s.period" xlink:actuate="onLoad" xmlns:xlink="http://www.w3.org/1999/xlink"></Period>' %(base_url[0],filename,period_id)
+            response = response.replace(original_period, xlink_period)
+    else:
+        # Start manipulating the original period so that it looks like .period in static xlink file.
+        filename = filename.split('+')[1] # Second part of string has the period id.
+        start_pos_xmlns = response.find("xmlns=")
+        end_pos_xmlns = response.find('"',start_pos_xmlns+7)+1
+        start_pos_period = response.find(filename[:-7])-12 # Find the position in the string file of the period that has be replaced
+        end_pos_period   = response.find("</Period>",start_pos_period)+9 # End position of the corresponding period.
+        original_period = response[start_pos_period:end_pos_period]
+        original_period = original_period.replace('">','" ' + response[start_pos_xmlns:end_pos_xmlns] + '>',1)
+        xml_intro = '<?xml version="1.0" encoding="utf-8"?>\n'
+        response = xml_intro + original_period
+    return response
 
 class DashProvider(object):
     "Provide DASH manifest and segments."
@@ -190,10 +220,24 @@ class DashProvider(object):
         cfg_processor = ConfigProcessor(self.vod_conf_dir, self.base_url)
         cfg_processor.process_url(self.url_parts, self.now)
         cfg = cfg_processor.getconfig()
-        if cfg.ext == ".mpd":
-            mpd_filename = "%s/%s/%s" % (self.content_dir, cfg.content_name, cfg.filename)
+        if cfg.ext == ".mpd" or cfg.ext == ".period":
+            if cfg.ext == ".period":
+                mpd_filename = "%s/%s/%s" % (self.content_dir, cfg.content_name, cfg.filename.split('+')[0])
+                # Get the first part of the string only, which is the .manifest file name.
+            else:
+                mpd_filename = "%s/%s/%s" % (self.content_dir, cfg.content_name, cfg.filename)
             mpd_input_data = cfg_processor.get_mpd_data()
             response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
+            nr_xlink_periods_per_hour = min(mpd_input_data['xlinkPeriodsPerHour'], 60)
+            if nr_xlink_periods_per_hour > 0: # -1 is the default value, which means no xlink are created.
+                nr_periods_per_hour = min(mpd_input_data['periodsPerHour'], 60) # See exception description for explanation.
+                one_xlinks_for_how_many_periods =  float(nr_periods_per_hour)/nr_xlink_periods_per_hour
+                if nr_periods_per_hour == -1:
+                    response = self.error_response("Xlinks can only be created for a multiperiod service.")
+                elif one_xlinks_for_how_many_periods != int(one_xlinks_for_how_many_periods): # The same kind of exception that was applied for periods.
+                    response = self.error_response("(Number of periods per hour/ Number of xlinks per hour) should be an integer.")
+                else:
+                    response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour, nr_xlink_periods_per_hour)
         elif cfg.ext == ".mp4":
             if self.now < cfg.availability_start_time_in_s - cfg.init_seg_avail_offset:
                 diff = (cfg.availability_start_time_in_s - cfg.init_seg_avail_offset) - self.now_float

--- a/dashlivesim/tests/test_xlinkperiod.py
+++ b/dashlivesim/tests/test_xlinkperiod.py
@@ -45,19 +45,21 @@ class TestXlinkPeriod(unittest.TestCase):
 
     def testMpdPeriodReplaced(self):
         " Check whether appropriate periods have been replaced by in .mpd file"
-        nr_period_per_hour = 2
-        nr_xlink_periods_per_hour = 2
-        urlParts = ['livesim', 'periods_%s' %nr_period_per_hour, 'xlink_%s' %nr_xlink_periods_per_hour, 'testpic_2s', 'Manifest.mpd']
-        dp = dash_proxy.DashProvider("10.4.247.98", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
-        d = dp.handle_request()
-        period_id_all = findall('Period id="([^"]*)"', d)
-        # Find all period ids in the .mpd file returned.
-        # We will check whether the correct periods have been xlinked here.
-        one_xlinks_for_how_many_periods =  nr_period_per_hour/nr_xlink_periods_per_hour
-        period_id_xlinks = [int(x[1:]) % one_xlinks_for_how_many_periods for x in period_id_all]
-        # All the period ids.
-        # If there were any periods, that were not supposed to be there,
-        # then one of the elements in period_id_xlinks would be zero.
-        result = 0
-        result = reduce(mul, period_id_xlinks, 1)
-        self.assertTrue(result != 0)
+        collectresult = 1
+        for k in [1, 2, 5, 10]:
+            nr_period_per_hour = 10
+            nr_xlink_periods_per_hour = k
+            urlParts = ['livesim', 'periods_%s' %nr_period_per_hour, 'xlink_%s' %nr_xlink_periods_per_hour, 'testpic_2s', 'Manifest.mpd']
+            dp = dash_proxy.DashProvider("10.4.247.98", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
+            d = dp.handle_request()
+            period_id_all = findall('Period id="([^"]*)"', d)
+            # Find all period ids in the .mpd file returned.
+            # We will check whether the correct periods have been xlinked here.
+            one_xlinks_for_how_many_periods =  nr_period_per_hour/nr_xlink_periods_per_hour
+            period_id_xlinks = [int(x[1:]) % one_xlinks_for_how_many_periods for x in period_id_all]
+            # All the period ids.
+            # If there were any periods, that were not supposed to be there,
+            # then one of the elements in period_id_xlinks would be zero.
+            result = reduce(mul, period_id_xlinks, 1)
+            collectresult = result * collectresult
+        self.assertTrue(collectresult != 0)

--- a/dashlivesim/tests/test_xlinkperiod.py
+++ b/dashlivesim/tests/test_xlinkperiod.py
@@ -1,0 +1,52 @@
+# The copyright in this software is being made available under the BSD License,
+# included below. This software may be subject to other third party and contributor
+# rights, including patent rights, and no such rights are granted under this license.
+#
+# Copyright (c) 2015, Dash Industry Forum.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation and/or
+#  other materials provided with the distribution.
+#  * Neither the name of Dash Industry Forum nor the names of its
+#  contributors may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+#  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from dash_test_util import *
+from ..dashlib import dash_proxy
+from re import findall
+from operator import mul
+
+
+class TestXlinkPeriod(unittest.TestCase):
+    def testMpdPeriodReplaced(self):
+        "Check whether appropriate periods have been replaced by in .mpd file"
+        nr_period_per_hour = 60
+        nr_xlink_periods_per_hour = 6
+        urlParts = ['livesim', 'periods_%s' %nr_period_per_hour, 'xlink_%s' %nr_xlink_periods_per_hour, 'testpic_2s', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("10.4.247.79", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
+        d = dp.handle_request()
+        period_id_all = findall('Period id="([^"]*)"', d)  # Find all period ids in the .mpd file retured.
+        # We will check whether the correct periods have been xlinked here.
+        one_xlinks_for_how_many_periods =  nr_period_per_hour/nr_xlink_periods_per_hour
+        period_id_xlinks = [int(x[1:]) % one_xlinks_for_how_many_periods for x in period_id_all] # All the period ids.
+        # If there were any periods, that were not supposed to be there, then one of the elements in period_id_xlinks woudl be zero.
+        result = reduce(mul, period_id_xlinks, 1)
+        self.assertTrue(result != 0)

--- a/dashlivesim/tests/test_xlinkperiod.py
+++ b/dashlivesim/tests/test_xlinkperiod.py
@@ -33,20 +33,31 @@ from dash_test_util import *
 from ..dashlib import dash_proxy
 from re import findall
 from operator import mul
-
+from ..dashlib import mpdprocessor
 
 class TestXlinkPeriod(unittest.TestCase):
+
+    def setUp(self):
+        mpdprocessor.SET_BASEURL = True
+
+    def tearDown(self):
+        mpdprocessor.SET_BASEURL = True
+
     def testMpdPeriodReplaced(self):
-        "Check whether appropriate periods have been replaced by in .mpd file"
-        nr_period_per_hour = 60
-        nr_xlink_periods_per_hour = 6
+        " Check whether appropriate periods have been replaced by in .mpd file"
+        nr_period_per_hour = 2
+        nr_xlink_periods_per_hour = 2
         urlParts = ['livesim', 'periods_%s' %nr_period_per_hour, 'xlink_%s' %nr_xlink_periods_per_hour, 'testpic_2s', 'Manifest.mpd']
-        dp = dash_proxy.DashProvider("10.4.247.79", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
+        dp = dash_proxy.DashProvider("10.4.247.98", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
         d = dp.handle_request()
-        period_id_all = findall('Period id="([^"]*)"', d)  # Find all period ids in the .mpd file retured.
+        period_id_all = findall('Period id="([^"]*)"', d)
+        # Find all period ids in the .mpd file returned.
         # We will check whether the correct periods have been xlinked here.
         one_xlinks_for_how_many_periods =  nr_period_per_hour/nr_xlink_periods_per_hour
-        period_id_xlinks = [int(x[1:]) % one_xlinks_for_how_many_periods for x in period_id_all] # All the period ids.
-        # If there were any periods, that were not supposed to be there, then one of the elements in period_id_xlinks woudl be zero.
+        period_id_xlinks = [int(x[1:]) % one_xlinks_for_how_many_periods for x in period_id_all]
+        # All the period ids.
+        # If there were any periods, that were not supposed to be there,
+        # then one of the elements in period_id_xlinks would be zero.
+        result = 0
         result = reduce(mul, period_id_xlinks, 1)
         self.assertTrue(result != 0)

--- a/dashlivesim/tests/testpic_2s.cfg
+++ b/dashlivesim/tests/testpic_2s.cfg
@@ -1,0 +1,21 @@
+[Setup]
+default_tsbd_secs = 300
+segment_duration_s = 2
+first_segment_in_loop = 1
+nr_segments_in_loop = 1800
+
+[audio]
+representations = A48
+timescale = 48000
+
+[video]
+representations = V300
+timescale = 90000
+
+[subtitles]
+representations = S1,sub_eng,sub_swe,sub_eng_cap,S1_one_region,S1_two_regions,sub_ttml_qbb,sub_nor, S1_two_regions_multi_color
+timescale = 1000
+
+[General]
+version = 1.0
+

--- a/dashlivesim/tests/testpic_2s/Manifest.mpd
+++ b/dashlivesim/tests/testpic_2s/Manifest.mpd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264" maxSegmentDuration="PT2S" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT1H">
+   <ProgramInformation>
+      <Title>Media Presentation Description by MobiTV. Powered by MDL Team@Sweden.</Title>
+   </ProgramInformation>
+   <Period id="precambrian" start="PT0S">
+      <AdaptationSet contentType="audio" mimeType="audio/mp4" lang="eng" segmentAlignment="true" startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+         <SegmentTemplate startNumber="1" initialization="$RepresentationID$/init.mp4" duration="2" media="$RepresentationID$/$Number$.m4s"/>
+         <Representation id="A48" codecs="mp4a.40.2" bandwidth="48000" audioSamplingRate="48000">
+            <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" par="16:9" minWidth="640" maxWidth="640" minHeight="360" maxHeight="360" maxFrameRate="60/2">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+         <SegmentTemplate startNumber="1" initialization="$RepresentationID$/init.mp4" duration="2" media="$RepresentationID$/$Number$.m4s"/>
+         <Representation id="V300" codecs="avc1.64001e" bandwidth="300000" width="640" height="360" frameRate="60/2" sar="1:1"/>
+      </AdaptationSet>
+   </Period>
+</MPD>


### PR DESCRIPTION
Currently, in the dash-live-source- simulator multiple periods are generated by specifying periods_n in the url. We would like to make few of these multi periods to be accessible via xlink.

This functionality has been implemented in the simulator. The url should look something like:
>http://server/periods_n/xlink_m/Manifest.mpd

The above url would result in creating a multi-period live service with n periods per hour, where m period per hour would be accessed via xlink. One xlink period is created for every n/m periods.  
