### PR TITLE
Add a new function to compress the "S" elements in SegmentTimeline

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -71,6 +71,7 @@ class Config(object):
         self.periods_per_hour = -1 # If > 0, generates that many periods per hour. If 0, only one offset period.
         self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
         self.seg_timeline = False # This flag is only true when there is /segtimeline_1/ in the URL
+        self.s_compress = False # This flag is only true when there is /r_1/ in the URL
         self.multi_url = [] # If not empty, give multiple URLs in the BaseURL element
         self.period_offset = -1 # Make one period with an offset compared to ast
         self.scte35_per_minute = 0 # Number of 10s ads per minute. Maximum 3
@@ -262,7 +263,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "continuous", "segtimeline", "baseurl", "peroff", "scte35", "utc", "snr")
+                    "periods", "continuous", "segtimeline", "r", "baseurl", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -281,6 +282,7 @@ class ConfigProcessor(object):
                'periodsPerHour' : self.cfg.periods_per_hour,
                'continuous' : self.cfg.cont_multiperiod,
                'segtimeline' : self.cfg.seg_timeline,
+               'compress_s_element' : self.cfg.s_compress,
                'urls' : self.cfg.multi_url,
                'periodOffset' : self.cfg.period_offset,
                'publishTime' : self.cfg.publish_time,
@@ -330,6 +332,9 @@ class ConfigProcessor(object):
             elif key == "segtimeline": # Only valid when it's set to 1
                 if int(value) == 1:
                     cfg.seg_timeline = True
+            elif key == "r": # Only valid when it's set to 1
+                if int(value) == 1:
+                    cfg.s_compress = True
             elif key == "baseurl": # Use multiple URLs, put all the configuration strings in multi_url
                 cfg.multi_url.append(value)
             elif key == "peroff": # Set the period offset

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -234,6 +234,7 @@ class DashProvider(object):
         mpd_proc_cfg = {'scte35Present' : (cfg.scte35_per_minute > 0),
                         'continuous' : in_data['continuous'],
                         'segtimeline' : in_data['segtimeline'],
+                        'compress_s_element' : in_data['compress_s_element'],
                         'utc_timing_methods' : cfg.utc_timing_methods,
                         'utc_head_url' : self.utc_head_url,
                         'now' : now}

--- a/dashlivesim/tests/test_mpdprocessor.py
+++ b/dashlivesim/tests/test_mpdprocessor.py
@@ -39,7 +39,7 @@ class TestMpdProcessor(unittest.TestCase):
 
     def setUp(self):
         self.cfg = {'scte35Present' : False, 'utc_timing_methods' : [], 'utc_head_url' : "",
-                    'continuous' : False, 'segtimeline' : False}
+                    'continuous' : False, 'segtimeline' : False, 'compress_s_element': False}
 
     def test_mpd_in_out(self):
 

--- a/dashlivesim/tests/test_segmenttimeline.py
+++ b/dashlivesim/tests/test_segmenttimeline.py
@@ -82,6 +82,17 @@ class TestMediaSegments(unittest.TestCase):
         self.assertEqual(len(time_seg), len(nr_seg))
         self.assertEqual(time_seg, nr_seg)
 
+class TestMPDWithSegmentTimelineCompressedS(unittest.TestCase):
+    "Test that the MPD looks correct when segtimeline_1 and r_1 are defined."
 
+    def setUp(self):
+        urlParts = ['livesim', 'segtimeline_1', 'r_1', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("server.org", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=8000)
+        self.d = dp.handle_request()
 
+    def testThatSElementIsCompressed(self):
+        testOutputFile = "segtimeline_s_compress.mpd"
+        rm_outfile(testOutputFile)
+        write_data_to_outfile(self.d, testOutputFile)
+        self.assertEqual(self.d.count('r="-1"'), 2)
 


### PR DESCRIPTION
If the durations of continuous "S" elements are the same, only the first "S" element will be present with r="-1" in the mpd file. Currently this compression is done only once from the down to top, which means that if there're more than one place needed for compression in a SegmentTemplate, only the last one will be handled. This function is available when /segtimeline_1/ and /r_1/ are both present in the request URL.