### PR TITLE
Support for other UTC timing methods (new)

### DIFF
--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -44,6 +44,8 @@ from . import scte35
 
 SET_BASEURL = True
 DASH_NAMESPACE = "{urn:mpeg:dash:schema:mpd:2011}"
+UTC_TIMING_NTP_SERVER = '1.de.pool.ntp.org'
+UTC_TIMING_SNTP_SERVER = 'time.kfki.hu'
 
 RE_NAMESPACE_TAG = re.compile(r"({.*})?(.*)")
 
@@ -390,6 +392,12 @@ class MpdProcessor(object):
             elif utc_method == "head":
                 time_elem = self.create_descriptor_elem('UTCTiming', 'urn:mpeg:dash:utc:http-head:2014',
                                                         self.utc_head_url)
+            elif utc_method == "ntp":
+                time_elem = self.create_descriptor_elem('UTCTiming', 'urn:mpeg:dash:utc:ntp:2014',
+                                                        UTC_TIMING_NTP_SERVER)
+            elif utc_method == "sntp":
+                time_elem = self.create_descriptor_elem('UTCTiming', 'urn:mpeg:dash:utc:sntp:2014',
+                                                        UTC_TIMING_SNTP_SERVER)
             else: #Unknown or un-implemented UTCTiming method
                 raise MpdModifierError("Unknown UTCTiming method: %s" % utc_method)
             mpd.insert(pos, time_elem)


### PR DESCRIPTION
* Earlier, only direct and http-head methods were supported.
* Now, ntp and sntp utc timing methods are also added.
* One thing to take care would be is that the dash.if server should be synced to the ntp server.