### PR TITLE
Support for early terminated periods (new)

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -72,6 +72,8 @@ class Config(object):
         self.cont = False # Continuous update of MPD AST and seg_nr.
         self.periods_per_hour = -1 # If > 0, generates that many periods per hour. If 0, only one offset period.
         self.xlink_periods_per_hour = -1 # Number of periods per hour that are accessed via xlink.
+        self.etp_periods_per_hour = -1 # Number of periods per hour that are accessed via xlink.
+        self.etp_duration = -1 # Duration of the early-terminated period.
         self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
         self.seg_timeline = False # This flag is only true when there is /segtimeline_1/ in the URL
         self.multi_url = [] # If not empty, give multiple URLs in the BaseURL element
@@ -267,7 +269,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "xlink", "continuous", "segtimeline", "baseurl", "peroff", "scte35", "utc", "snr")
+                    "periods", "xlink", "etp", "etpDuration", "continuous", "segtimeline", "baseurl", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -285,6 +287,8 @@ class ConfigProcessor(object):
                'startNumber' : self.cfg.availability_start_time_in_s//self.cfg.seg_duration,
                'periodsPerHour' : self.cfg.periods_per_hour,
                'xlinkPeriodsPerHour' : self.cfg.xlink_periods_per_hour,
+               'etpPeriodsPerHour' : self.cfg.etp_periods_per_hour,
+               'etpDuration' : self.cfg.etp_duration,
                'continuous' : self.cfg.cont_multiperiod,
                'segtimeline' : self.cfg.seg_timeline,
                'urls' : self.cfg.multi_url,
@@ -332,6 +336,10 @@ class ConfigProcessor(object):
                 cfg.periods_per_hour = int(value)
             elif key == "xlink": # Make periods access via xlink.
                 cfg.xlink_periods_per_hour = int(value)
+            elif key == "etp": # Make periods access via xlink.
+                cfg.etp_periods_per_hour = int(value)
+            elif key == "etpDuration": # Add a presentation duration for multiple periods
+                cfg.etp_duration = int(value)
             elif key == "continuous": # Only valid when it's set to 1 and periods_per_hour is set
                 if int(value) == 1:
                     cfg.cont_multiperiod = True

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -131,6 +131,25 @@ def generate_period_data(mpd_data, now):
             data = {'id' : "p%d" % period_nr, 'start' : 'PT%dS' % (period_nr*period_duration),
                     'startNumber' : "%d" % (start_time/seg_dur), 'duration' : seg_dur,
                     'presentationTimeOffset' : period_nr*period_duration}
+            if mpd_data['etpPeriodsPerHour'] > 0:
+                # Check whether the early terminated feature is enabled or not.
+                # If yes, then proceed.
+                nr_etp_periods_per_hour = min(mpd_data['etpPeriodsPerHour'], 60)
+                # Limit the maximum value to 60, same as done for the period.
+                fraction_nr_periods_to_nr_etp = float(nr_periods_per_hour)/nr_etp_periods_per_hour
+                if fraction_nr_periods_to_nr_etp != int(fraction_nr_periods_to_nr_etp):
+                    raise Exception("(Number of periods per hour/ Number of etp periods per hour) "
+                                    "should be an integer.")
+                etp_duration = mpd_data['etpDuration']
+                if etp_duration == -1:
+                    etp_duration = period_duration / 2
+                    # Default value
+                    # If no etpDuration is specified, then we take a default values, i.e, half of period duration.
+                if etp_duration > period_duration:
+                    raise Exception("Duration of the early terminated period should be less that the duration of a "
+                                    "regular period")
+                if period_nr % fraction_nr_periods_to_nr_etp == 0:
+                    data['etpDuration'] = etp_duration
             period_data.append(data)
     return period_data
 

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -336,6 +336,8 @@ class MpdProcessor(object):
         last_period_id = '-1'
         for (period, pdata) in zip(periods, period_data):
             set_attribs(period, ('id', 'start'), pdata)
+            if pdata.has_key('etpDuration'):
+                period.set('duration', "PT%dS" % pdata['etpDuration'])
             segmenttemplate_attribs = ['startNumber']
             pto = pdata['presentationTimeOffset']
             if pto:

--- a/dashlivesim/tests/test_earlyterminatedperiod.py
+++ b/dashlivesim/tests/test_earlyterminatedperiod.py
@@ -1,0 +1,73 @@
+# The copyright in this software is being made available under the BSD License,
+# included below. This software may be subject to other third party and contributor
+# rights, including patent rights, and no such rights are granted under this license.
+#
+# Copyright (c) 2015, Dash Industry Forum.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation and/or
+#  other materials provided with the distribution.
+#  * Neither the name of Dash Industry Forum nor the names of its
+#  contributors may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+#  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from dash_test_util import *
+from ..dashlib import dash_proxy
+from re import findall
+from operator import mul
+from ..dashlib import mpdprocessor
+import xml.etree.ElementTree as ET
+
+
+class TestXlinkPeriod(unittest.TestCase):
+
+    def setUp(self):
+        mpdprocessor.SET_BASEURL = True
+
+    def tearDown(self):
+        mpdprocessor.SET_BASEURL = True
+
+    def testMpdPeriodReplaced(self):
+        " Check whether appropriate periods have been replaced by in .mpd file"
+        collectresult = 0
+        for k in [1, 2, 5, 10, 20, 30]:
+            nr_period_per_hour = 60
+            nr_etp_periods_per_hour = k
+            urlParts = ['livesim', 'periods_%s' %nr_period_per_hour, 'etp_%s' %nr_etp_periods_per_hour, 'testpic_2s', 'Manifest.mpd']
+            dp = dash_proxy.DashProvider("10.4.247.98", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
+            d = dp.handle_request()
+            xml = ET.fromstring(d)
+            # Make the string as a xml document.
+            periods_containing_duration_attribute = []
+            # This array would contain all the period id that have duration attributes.
+            # In the following, we will check if the correct period element have been assigned duration attributes.
+            for child in xml.findall('{urn:mpeg:dash:schema:mpd:2011}Period'): # Collect all period elements first
+                if child.attrib.has_key('duration'): # If the period element has the duration attribute.
+                    periods_containing_duration_attribute.append(child.attrib['id']) # Then collect its period id in this
+                                                                                     # array
+            one_etp_for_how_many_periods =  nr_period_per_hour/nr_etp_periods_per_hour
+            checker_array = [int(x[1:]) % one_etp_for_how_many_periods for x in periods_containing_duration_attribute]
+            # In the above line, we check if each period id evaluates to zero or not.
+            # Ideally, if everything worked well, then the checker array would be all zero.
+            collectresult = collectresult + sum(checker_array)
+            # Here, we keep collecting the sum of checker array. Even if one element evaluates to non zero values, then
+            # the whole test will fail.
+        self.assertTrue(collectresult == 0)


### PR DESCRIPTION
For details about this PR, please refer to the following document : 
>[earlyTerminatedPeriod.pdf](https://github.com/Dash-Industry-Forum/dash-live-source-simulator/files/103048/earlyTerminatedPeriod.pdf)

What follows is a summary of the details present in the document.

* We are creating early terminated periods in the dash-live-simulator.
* We achieve this by passing two argument to the url like so :
 * http://server/livesim/periods_60/etp_10/etpDuration_10/Manifest.mpd
* The above url implies two things:
 *  How often the early terminated periods are created ?  For example, etp_10 implies 10 early terminated periods (ETPs) are created in one hour.
 * When is this period terminated ? For example, etpDuration_10 implies each ETP is terminated at 10 seconds.
* A robust unit test (we extract the .xml parameters) is also written with this commit.
* All possible combination of values for etp and etpDuration are not possible, invalid combinations raise an exception.

