### PR TITLE
Added feature for ad insertion.

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -74,6 +74,7 @@ class Config(object):
         self.xlink_periods_per_hour = -1 # Number of periods per hour that are accessed via xlink.
         self.etp_periods_per_hour = -1 # Number of periods per hour that are accessed via xlink.
         self.etp_duration = -1 # Duration of the early-terminated period.
+        self.insert_ad = -1 # Number of periods per hour that are accessed via xlink.
         self.cont_multiperiod = False # This flag should only be used when periods_per_hour is set
         self.seg_timeline = False # This flag is only true when there is /segtimeline_1/ in the URL
         self.multi_url = [] # If not empty, give multiple URLs in the BaseURL element
@@ -269,7 +270,7 @@ class ConfigProcessor(object):
     "Process the url and VoD config files and setup configuration."
 
     url_cfg_keys = ("start", "ast", "dur", "init", "tsbd", "mup", "modulo", "all", "tfdt", "cont",
-                    "periods", "xlink", "etp", "etpDuration", "continuous", "segtimeline", "baseurl", "peroff", "scte35", "utc", "snr")
+                    "periods", "xlink", "etp", "etpDuration", "insertad", "continuous", "segtimeline", "baseurl", "peroff", "scte35", "utc", "snr")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -289,6 +290,7 @@ class ConfigProcessor(object):
                'xlinkPeriodsPerHour' : self.cfg.xlink_periods_per_hour,
                'etpPeriodsPerHour' : self.cfg.etp_periods_per_hour,
                'etpDuration' : self.cfg.etp_duration,
+               'insertAd' : self.cfg.insert_ad,
                'continuous' : self.cfg.cont_multiperiod,
                'segtimeline' : self.cfg.seg_timeline,
                'urls' : self.cfg.multi_url,
@@ -311,7 +313,7 @@ class ConfigProcessor(object):
         url_pos = 0
         for part in url_parts: # Should be listed in self.configParts to make sure it works.
             cfg_parts = part.split("_", 1)
-            if not cfg_parts[0] in self.url_cfg_keys: #Must handle content like testpic_2s
+            if cfg_parts[0] not in self.url_cfg_keys: #Must handle content like testpic_2s
                 break
             key, value = cfg_parts
             if key == "start" or key == "ast": # Change availability start time in s.
@@ -340,6 +342,8 @@ class ConfigProcessor(object):
                 cfg.etp_periods_per_hour = int(value)
             elif key == "etpDuration": # Add a presentation duration for multiple periods
                 cfg.etp_duration = int(value)
+            elif key == "insertad": # Make periods access via xlink.
+                cfg.insert_ad = int(value)
             elif key == "continuous": # Only valid when it's set to 1 and periods_per_hour is set
                 if int(value) == 1:
                     cfg.cont_multiperiod = True

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -71,9 +71,9 @@ from . import segmentmuxer
 from . import mpdprocessor
 from .timeformatconversions import make_timestamp, seconds_to_iso_duration
 from .configprocessor import ConfigProcessor
+from xml.etree import ElementTree as ET
 
-
-SECS_IN_DAY = 24*3600
+SECS_IN_DAY = 24 * 3600
 DEFAULT_MINIMUM_UPDATE_PERIOD = "P100Y"
 DEFAULT_PUBLISH_ADVANCE_IN_S = 7200
 EXTRA_TIME_AFTER_END_IN_S = 60
@@ -81,6 +81,7 @@ EXTRA_TIME_AFTER_END_IN_S = 60
 UTC_HEAD_PATH = "dash/time.txt"
 
 PUBLISH_TIME = False
+
 
 def handle_request(host_name, url_parts, args, vod_conf_dir, content_dir, now=None, req=None, is_https=0):
     "Handle Apache request."
@@ -91,6 +92,7 @@ def handle_request(host_name, url_parts, args, vod_conf_dir, content_dir, now=No
 class DashProxyError(Exception):
     "Error in DashProxy."
 
+
 class DashSegmentNotAvailableError(DashProxyError):
     "Segment not available."
 
@@ -99,33 +101,38 @@ def generate_period_data(mpd_data, now):
     """Generate an array of period data depending on current time (now). 0 gives one period with start offset.
 
     mpd_data is changed (minimumUpdatePeriod)."""
-    #pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals
 
     nr_periods_per_hour = min(mpd_data['periodsPerHour'], 60)
-    if not nr_periods_per_hour in (-1, 0, 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60):
+    if nr_periods_per_hour not in (-1, 0, 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60):
         raise Exception("Bad nr of periods per hour %d" % nr_periods_per_hour)
 
     seg_dur = mpd_data['segDuration']
     period_data = []
-    if nr_periods_per_hour == -1: # Just one period starting at at time start relative AST
+    ad_frequency = -1
+    if mpd_data['insertAd'] > 0:
+        ad_frequency = nr_periods_per_hour / mpd_data['xlinkPeriodsPerHour']
+
+    if nr_periods_per_hour == -1:  # Just one period starting at at time start relative AST
         start = 0
-        start_number = mpd_data['startNumber'] + start/seg_dur
-        data = {'id' : "p0", 'start' : 'PT%dS' % start, 'startNumber' : str(start_number),
-                'duration' : seg_dur, 'presentationTimeOffset' : "%d" % mpd_data['presentationTimeOffset']}
+        start_number = mpd_data['startNumber'] + start / seg_dur
+        data = {'id': "p0", 'start': 'PT%dS' % start, 'startNumber': str(start_number),
+                'duration': seg_dur, 'presentationTimeOffset': "%d" % mpd_data['presentationTimeOffset']}
         period_data.append(data)
-    elif nr_periods_per_hour == 0: # nrPeriodsPerHour == 0, make one old period but starting 1000h after epoch
-        start = 3600*1000
-        data = {'id' : "p0", 'start' : 'PT%dS' % start, 'startNumber' : "%d" % (start/seg_dur),
-                'duration' : seg_dur, 'presentationTimeOffset' : "%d" % start}
+    elif nr_periods_per_hour == 0:  # nrPeriodsPerHour == 0, make one old period but starting 1000h after epoch
+        start = 3600 * 1000
+        data = {'id': "p0", 'start': 'PT%dS' % start, 'startNumber': "%d" % (start / seg_dur),
+                'duration': seg_dur, 'presentationTimeOffset': "%d" % start}
         period_data.append(data)
-    else: #  nr_periods_per_hour > 0
-        period_duration = 3600/nr_periods_per_hour
-        minimum_update_period = "PT%dS" % (period_duration/2 - 5)
+    else:  # nr_periods_per_hour > 0
+        period_duration = 3600 / nr_periods_per_hour
+        minimum_update_period = "PT%dS" % (period_duration / 2 - 5)
         mpd_data['minimumUpdatePeriod'] = minimum_update_period
-        this_period_nr = now/period_duration
-        nr_periods_back = mpd_data['timeShiftBufferDepthInS']/period_duration + 1
+        this_period_nr = now / period_duration
+        nr_periods_back = mpd_data['timeShiftBufferDepthInS'] / period_duration + 1
         start_period_nr = this_period_nr - nr_periods_back
         last_period_nr = this_period_nr + 1
+        counter = 0
         for period_nr in range(start_period_nr, last_period_nr+1):
             start_time = period_nr*period_duration
             data = {'id' : "p%d" % period_nr, 'start' : 'PT%dS' % (period_nr*period_duration),
@@ -151,9 +158,14 @@ def generate_period_data(mpd_data, now):
                 if period_nr % fraction_nr_periods_to_nr_etp == 0:
                     data['etpDuration'] = etp_duration
             period_data.append(data)
+            if ad_frequency > 0 and ((period_nr % ad_frequency) == 0) and counter > 0:
+                period_data[counter - 1]['periodDuration'] = 'PT%dS' % period_duration
+            counter = counter + 1
+            # print period_data
     return period_data
 
-def generate_response_with_xlink(response, cfg, filename, nr_periods_per_hour, nr_xlink_periods_per_hour):
+
+def generate_response_with_xlink(response, cfg, filename, nr_periods_per_hour, nr_xlink_periods_per_hour, insert_ad):
     "Convert the normally created response into a response which has xlinks"
     # This functions has two functionality : 1.For MPD and 2.For PERIOD.
     # 1. When the normally created .mpd file is fed to this function, it removes periods and inserts xlink for the
@@ -162,42 +174,90 @@ def generate_response_with_xlink(response, cfg, filename, nr_periods_per_hour, n
     # adds some information and returns the appropriate .xml document to the java client.
     # pylint: disable=too-many-locals, too-many-statements
     if cfg == ".mpd":
-        period_id_all = findall('Period id="([^"]*)"', response)
+        root = ET.fromstring(response)
+        period_id_all = []
+        for child in root.findall('{urn:mpeg:dash:schema:mpd:2011}Period'):
+            period_id_all.append(child.attrib['id'])
+        # period_id_all = findall('Period id="([^"]*)"', response)
         # Find all period ids in the response file.
-        one_xlinks_for_how_many_periods = nr_periods_per_hour/nr_xlink_periods_per_hour
+        one_xlinks_for_how_many_periods = nr_periods_per_hour / nr_xlink_periods_per_hour
         period_id_xlinks = [x for x in period_id_all if int(x[1:]) % one_xlinks_for_how_many_periods == 0]
         # Periods that will be replaced with links.
         base_url = findall('<BaseURL>([^"]*)</BaseURL>', response)
-        for period_id in period_id_xlinks:
+        counter = 0
+        for period_id in period_id_all:
             # Start replacing only if this condition is met.
-            start_pos_period = response.find(period_id)-12
+            start_pos_period = response.find(period_id) - 12
             # Find the position in the string file of the period that has be replaced
-            end_pos_period = response.find("</Period>", start_pos_period)+9
+            end_pos_period = response.find("</Period>", start_pos_period) + 9
             # End position of the corresponding period.
-            original_period = response[start_pos_period:end_pos_period]
-            xlink_period = '<Period xlink:href="%s%s+%s.period" xlink:actuate="onLoad" ' \
-                           'xmlns:xlink="http://www.w3.org/1999/xlink"></Period>' %(base_url[0], filename, period_id)
-            response = response.replace(original_period, xlink_period)
+            if period_id in period_id_xlinks:
+                counter += 1
+                original_period = response[start_pos_period:end_pos_period]
+                if insert_ad == 4:
+                    xlink_period = '<Period xlink:href="http://vm1.dashif.org/dynamicxlink/invalid' \
+                                   'url.php" xlink:actuate="onLoad" xmlns:xlink="http://www.w3.org/1999/xlink">' \
+                                   '</Period>'
+                elif insert_ad == 3:
+                    xlink_period = '<Period xlink:href="http://vm1.dashif.org/dynamicxlink/ad.php' \
+                                   '?id=6_ad_twoperiods_withremote" xlink:actuate="onLoad" xmlns:xlink="http://www.' \
+                                   'w3.org/1999/xlink"></Period>'
+                elif insert_ad == 2:
+                    xlink_period = '<Period xlink:href="http://vm1.dashif.org/dynamicxlink/ad.php' \
+                                   '?id=6_ad_twoperiods" xlink:actuate="onLoad" xmlns:xlink="http://www.w3.org/1999/' \
+                                   'xlink"></Period>'
+                elif insert_ad == 1 or insert_ad == 5:
+                    xlink_period = '<Period xlink:href="http://vm1.dashif.org/dynamicxlink/ad.php?' \
+                                   'id=6_ad" xlink:actuate="onLoad" xmlns:xlink="http://www.w3.org/1999/xlink">' \
+                                   '</Period>'
+                else:
+                    xlink_period = '<Period xlink:href="%s%s+%s.period" xlink:actuate="onLoad" ' \
+                                   'xmlns:xlink="http://www.w3.org/1999/xlink"></Period>' % (
+                                       base_url[0], filename, period_id)
+                if insert_ad > 0 and counter == 1:  # This condition ensures that the first period in the mpd is not
+                    # replaced when the ads are enabled.
+                    response = insert_asset_identifier(response,
+                                                       start_pos_period)  # Insert asset identifier,
+                                                                          # if the the period is not replaced.
+                    continue
+                if insert_ad == 5:  # Add additonal content for the default content
+                    start_pos_period_contents = original_period.find('>') + 1
+                    xlink_period = xlink_period[:-9] + '\n<!--Default content that will be played if the xlink is not' \
+                                                       ' able to load.-->' + original_period[start_pos_period_contents:]
+                response = response.replace(original_period, xlink_period)
+            else:
+                if insert_ad > 0:
+                    response = insert_asset_identifier(response, start_pos_period)
     else:
         # This will be done when ".period" file is being requested
         # Start manipulating the original period so that it looks like .period in the static xlink file.
         filename = filename.split('+')[1]
         # Second part of string has the period id.
         start_pos_xmlns = response.find("xmlns=")
-        end_pos_xmlns = response.find('"', start_pos_xmlns+7)+1
-        start_pos_period = response.find(filename[:-7])-12
+        end_pos_xmlns = response.find('"', start_pos_xmlns + 7) + 1
+        start_pos_period = response.find(filename[:-7]) - 12
         # Find the position in the string file of the period that has be replaced.
-        end_pos_period = response.find("</Period>", start_pos_period)+9
+        end_pos_period = response.find("</Period>", start_pos_period) + 9
         # End position of the corresponding period.
         original_period = response[start_pos_period:end_pos_period]
         original_period = original_period.replace('">', '" ' + response[start_pos_xmlns:end_pos_xmlns] + '>', 1)
-        xml_intro = '<?xml version="1.0" encoding="utf-8"?>\n'
-        response = xml_intro + original_period
+        # xml_intro = '<?xml version="1.0" encoding="utf-8"?>\n'
+        # response = xml_intro + original_period
+        response = original_period
     return response
+
+
+def insert_asset_identifier(response, start_pos_period):
+    ad_pos = response.find(">", start_pos_period) + 1
+    response = response[:ad_pos] + "\n<AssetIdentifier schemeIdUri=\"urn:org:dashif:asset-id:2013\" value=\"md:cid:" \
+                                   "EIDR:10.5240%2f0EFB-02CD-126E-8092-1E49-W\"></AssetIdentifier>" + response[ad_pos:]
+    return response
+
 
 class DashProvider(object):
     "Provide DASH manifest and segments."
-    #pylint: disable=too-many-instance-attributes,too-many-arguments
+
+    # pylint: disable=too-many-instance-attributes,too-many-arguments
 
     def __init__(self, host_name, url_parts, url_args, vod_conf_dir, content_dir, now=None, req=None, is_https=0):
         protocol = is_https and "https" or "http"
@@ -207,7 +267,7 @@ class DashProvider(object):
         self.url_args = url_args
         self.vod_conf_dir = vod_conf_dir
         self.content_dir = content_dir
-        self.now_float = now # float
+        self.now_float = now  # float
         self.now = int(now)
         self.req = req
         self.new_tfdt_value = None
@@ -220,9 +280,9 @@ class DashProvider(object):
         "Return a mod_python error response."
         if self.req:
             self.req.log_error("dash_proxy: [%s] %s" % ("/".join(self.url_parts[-3:]), msg))
-        return {'ok' : False, 'pl' : msg + "\n"}
+        return {'ok': False, 'pl': msg + "\n"}
 
-    #pylint:disable = too-many-locals, too-many-branches
+    # pylint:disable = too-many-locals, too-many-branches
     def parse_url(self):
         "Parse the absolute URL that is received in mod_python."
         cfg_processor = ConfigProcessor(self.vod_conf_dir, self.base_url)
@@ -235,22 +295,22 @@ class DashProvider(object):
             else:
                 mpd_filename = "%s/%s/%s" % (self.content_dir, cfg.content_name, cfg.filename)
             mpd_input_data = cfg_processor.get_mpd_data()
-            response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
             nr_xlink_periods_per_hour = min(mpd_input_data['xlinkPeriodsPerHour'], 60)
+            nr_periods_per_hour = min(mpd_input_data['periodsPerHour'], 60)
+            # See exception description for explanation.
             if nr_xlink_periods_per_hour > 0:
-                # -1 is the default value, which means no xlink are created.
-                nr_periods_per_hour = min(mpd_input_data['periodsPerHour'], 60)
-                # See exception description for explanation.
-                one_xlinks_for_how_many_periods = float(nr_periods_per_hour)/nr_xlink_periods_per_hour
                 if nr_periods_per_hour == -1:
-                    response = self.error_response("Xlinks can only be created for a multiperiod service.")
-                elif one_xlinks_for_how_many_periods != int(one_xlinks_for_how_many_periods):
-                    # The same kind of exception that was applied for periods.
-                    response = self.error_response("(Number of periods per hour/ Number of xlinks per hour) "
-                                                   "should be an integer.")
-                else:
-                    response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour,
-                                                            nr_xlink_periods_per_hour)
+                    raise Exception("Xlinks can only be created for a multiperiod service.")
+                one_xlinks_for_how_many_periods = float(nr_periods_per_hour) / nr_xlink_periods_per_hour
+                if one_xlinks_for_how_many_periods != int(one_xlinks_for_how_many_periods):
+                    raise Exception("(Number of periods per hour/ Number of xlinks per hour should be an integer.")
+            if mpd_input_data['insertAd'] > 0 and nr_xlink_periods_per_hour < 0:
+                raise Exception("Insert ad option can only be used in conjuction with the xlink option. To use the "
+                                "insert ad option, also set use xlink_m in your url.")
+            response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
+            if nr_xlink_periods_per_hour > 0:
+                response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour,
+                                                        nr_xlink_periods_per_hour, mpd_input_data['insertAd'])
         elif cfg.ext == ".mp4":
             if self.now < cfg.availability_start_time_in_s - cfg.init_seg_avail_offset:
                 diff = (cfg.availability_start_time_in_s - cfg.init_seg_avail_offset) - self.now_float
@@ -269,28 +329,28 @@ class DashProvider(object):
                 response = self.error_response("Request for %s after AET. %.1fs too late" % (cfg.filename, diff))
             else:
                 response = self.process_media_segment(cfg, self.now_float)
-                if len(cfg.multi_url) == 1: # There is one specific baseURL with losses specified
+                if len(cfg.multi_url) == 1:  # There is one specific baseURL with losses specified
                     a_var, b_var = cfg.multi_url[0].split("_")
                     dur1 = int(a_var[1:])
                     dur2 = int(b_var[1:])
                     total_dur = dur1 + dur2
-                    num_loop = int(ceil(60.0/(float(total_dur))))
+                    num_loop = int(ceil(60.0 / (float(total_dur))))
                     now_mod_60 = self.now % 60
-                    if a_var[0] == 'u' and b_var[0] == 'd': #parse server up or down information
+                    if a_var[0] == 'u' and b_var[0] == 'd':  # parse server up or down information
                         for i in range(num_loop):
-                            if i*total_dur + dur1 < now_mod_60 <= (i+1)*total_dur:
+                            if i * total_dur + dur1 < now_mod_60 <= (i + 1) * total_dur:
                                 response = self.error_response("BaseURL server down at %d" % (self.now))
                                 break
                     elif a_var[0] == 'd' and b_var[0] == 'u':
                         for i in range(num_loop):
-                            if i*(total_dur) < now_mod_60 <= i*(total_dur)+dur1:
+                            if i * (total_dur) < now_mod_60 <= i * (total_dur) + dur1:
                                 response = self.error_response("BaseURL server down at %d" % (self.now))
                                 break
         else:
             response = "Unknown file extension: %s" % cfg.ext
         return response
 
-    #pylint: disable=no-self-use
+    # pylint: disable=no-self-use
     def generate_dynamic_mpd(self, cfg, mpd_filename, in_data, now):
         "Generate the dynamic MPD."
         mpd_data = in_data.copy()
@@ -310,12 +370,12 @@ class DashProvider(object):
         mpd_data['presentationTimeOffset'] = 0
         if in_data.has_key('availabilityEndTime'):
             mpd_data['availabilityEndTime'] = make_timestamp(in_data['availabilityEndTime'])
-        mpd_proc_cfg = {'scte35Present' : (cfg.scte35_per_minute > 0),
-                        'continuous' : in_data['continuous'],
-                        'segtimeline' : in_data['segtimeline'],
-                        'utc_timing_methods' : cfg.utc_timing_methods,
-                        'utc_head_url' : self.utc_head_url,
-                        'now' : now}
+        mpd_proc_cfg = {'scte35Present': (cfg.scte35_per_minute > 0),
+                        'continuous': in_data['continuous'],
+                        'segtimeline': in_data['segtimeline'],
+                        'utc_timing_methods': cfg.utc_timing_methods,
+                        'utc_head_url': self.utc_head_url,
+                        'now': now}
         mpmod = mpdprocessor.MpdProcessor(mpd_filename, mpd_proc_cfg, cfg)
         period_data = generate_period_data(mpd_data, now)
         mpmod.process(mpd_data, period_data)
@@ -325,11 +385,11 @@ class DashProvider(object):
         "Read non-multiplexed or create muxed init segments."
 
         nr_reps = len(cfg.reps)
-        if nr_reps == 1: # Not muxed
+        if nr_reps == 1:  # Not muxed
             init_file = "%s/%s/%s/%s" % (self.content_dir, cfg.content_name, cfg.rel_path, cfg.filename)
             ilf = InitLiveFilter(init_file)
             data = ilf.filter()
-        elif nr_reps == 2: # Something that can be muxed
+        elif nr_reps == 2:  # Something that can be muxed
             com_path = "/".join(cfg.rel_path.split("/")[:-1])
             init1 = "%s/%s/%s/%s/%s" % (self.content_dir, cfg.content_name, com_path, cfg.reps[0]['id'], cfg.filename)
             init2 = "%s/%s/%s/%s/%s" % (self.content_dir, cfg.content_name, com_path, cfg.reps[1]['id'], cfg.filename)
@@ -343,7 +403,8 @@ class DashProvider(object):
         """Process media segment. Return error response if timing is not OK.
 
         Assumes that segment_ast = (seg_nr+1-startNumber)*seg_dur."""
-        #pylint: disable=too-many-locals
+
+        # pylint: disable=too-many-locals
 
         def get_timescale(cfg):
             "Get timescale for the current representation."
@@ -360,8 +421,8 @@ class DashProvider(object):
         seg_base, seg_ext = splitext(seg_name)
         timescale = get_timescale(cfg)
         if seg_base[0] == 't':
-            #TODO. Make a more accurate test here that the timestamp is a correct one
-            seg_nr = int(round(float(seg_base[1:])/seg_dur/timescale))
+            # TODO. Make a more accurate test here that the timestamp is a correct one
+            seg_nr = int(round(float(seg_base[1:]) / seg_dur / timescale))
         else:
             seg_nr = int(seg_base)
         seg_start_nr = cfg.start_nr == -1 and 1 or cfg.start_nr
@@ -372,7 +433,7 @@ class DashProvider(object):
             if seg_nr > very_last_segment:
                 return self.error_response("Request for segment %d beyond last (%d)" % (seg_nr, very_last_segment))
         lmsg = seg_nr in cfg.last_segment_numbers
-        #print cfg.last_segment_numbers
+        # print cfg.last_segment_numbers
         seg_time = (seg_nr - seg_start_nr) * seg_dur + cfg.availability_start_time_in_s
         seg_ast = seg_time + seg_dur
 
@@ -386,13 +447,13 @@ class DashProvider(object):
         time_since_ast = seg_time - cfg.availability_start_time_in_s
         loop_duration = cfg.seg_duration * cfg.vod_nr_segments_in_loop
         nr_loops_done, time_in_loop = divmod(time_since_ast, loop_duration)
-        offset_at_loop_start = nr_loops_done*loop_duration
-        seg_nr_in_loop = time_in_loop//seg_dur
+        offset_at_loop_start = nr_loops_done * loop_duration
+        seg_nr_in_loop = time_in_loop // seg_dur
         vod_nr = seg_nr_in_loop + cfg.vod_first_segment_in_loop
         assert 0 <= vod_nr - cfg.vod_first_segment_in_loop < cfg.vod_nr_segments_in_loop
         rel_path = cfg.rel_path
         nr_reps = len(cfg.reps)
-        if nr_reps == 1: # Not muxed
+        if nr_reps == 1:  # Not muxed
             seg_content = self.filter_media_segment(cfg, cfg.reps[0], rel_path, vod_nr, seg_nr, seg_ext,
                                                     offset_at_loop_start, lmsg)
         else:
@@ -408,7 +469,7 @@ class DashProvider(object):
             seg_content = muxed.mux_on_sample_level()
         return seg_content
 
-    #pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments
     def filter_media_segment(self, cfg, rep, rel_path, vod_nr, seg_nr, seg_ext, offset_at_loop_start, lmsg):
         "Filter an actual media segment by using time-scale from init segment."
         media_seg_file = join(self.content_dir, cfg.content_name, rel_path, "%d%s" % (vod_nr, seg_ext))
@@ -420,4 +481,3 @@ class DashProvider(object):
         seg_content = seg_filter.filter()
         self.new_tfdt_value = seg_filter.get_tfdt_value()
         return seg_content
-

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -340,6 +340,8 @@ class MpdProcessor(object):
             set_attribs(period, ('id', 'start'), pdata)
             if pdata.has_key('etpDuration'):
                 period.set('duration', "PT%dS" % pdata['etpDuration'])
+            if pdata.has_key('periodDuration'):
+                period.set('duration', pdata['periodDuration'])
             segmenttemplate_attribs = ['startNumber']
             pto = pdata['presentationTimeOffset']
             if pto:

--- a/dashlivesim/tests/test_adinsertion.py
+++ b/dashlivesim/tests/test_adinsertion.py
@@ -1,0 +1,65 @@
+# The copyright in this software is being made available under the BSD License,
+# included below. This software may be subject to other third party and contributor
+# rights, including patent rights, and no such rights are granted under this license.
+#
+# Copyright (c) 2015, Dash Industry Forum.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation and/or
+#  other materials provided with the distribution.
+#  * Neither the name of Dash Industry Forum nor the names of its
+#  contributors may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+#  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from dash_test_util import *
+from ..dashlib import dash_proxy
+from re import findall
+from operator import mul
+from ..dashlib import mpdprocessor
+import xml.etree.ElementTree as ET
+
+
+class TestXlinkPeriod(unittest.TestCase):
+
+    def setUp(self):
+        self.old_set_baseurl_value = mpdprocessor.SET_BASEURL
+        mpdprocessor.SET_BASEURL = True
+
+    def tearDown(self):
+        mpdprocessor.SET_BASEURL = self.old_set_baseurl_value
+
+    def testMpdPeriodReplaced(self):
+        " Check whether before every xlink period, duration attribute has been inserted"
+        collect_result = []
+        urlParts = ['livesim', 'periods_60', 'xlink_30', 'insertad_1', 'testpic_2s', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("10.4.247.98", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10000)
+        d = dp.handle_request()
+        xml = ET.fromstring(d)
+        # Make the string as a xml document.
+        # In the following, we will check if for every period before every xlink period, duration attribute has been
+        # added or not.
+        prev_child = []
+        for child in xml.findall('{urn:mpeg:dash:schema:mpd:2011}Period'): # Collect all period elements first
+            if child.attrib.has_key('{http://www.w3.org/1999/xlink}actuate'): # If the period element has the duration attribute.
+                collect_result.append(prev_child.attrib.has_key('duration')) # Then collect its period id in this
+            prev_child = child
+        # Ideally, at the periods should have a duration attribute, if no then the test fails.
+        self.assertTrue((False in collect_result) == False)


### PR DESCRIPTION
For detailed description about this PR, refer the following document.
>[adinsertion.pdf](https://github.com/Dash-Industry-Forum/dash-live-source-simulator/files/115652/adinsertion.pdf)

What follows is a summary of the above document.


* The current version of the live-source-simulator supports xlink remote periods.
But the periods that xlink refer to are part of the live content itself. Instead of
xlinks referring to the its own content, we want the xlinks to refer to on-demand
ads now.

* In this PR, we extend the functionality to insert on-demand ADs.

* In this PR, I have also implemented features that will help to insert on demand ADs.

   -  Duration attribute before AD's

   -  Asset identifier for continuous periods
