### PR TITLE
presentationTimeOffset in SegmentTemplate should use local timescale

### DIFF
--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -282,6 +282,9 @@ class MpdProcessor(object):
                         remove_attribs(seg_template, ['duration'])
                         remove_attribs(seg_template, ['startNumber'])
                         seg_template.set('timescale', str(self.cfg.media_data[content_type]['timescale']))
+                        if pto and not offset_at_period_level:
+                            # rescale presentationTimeOffset based on the local timescale
+                            seg_template.set('presentationTimeOffset', str(pto * int(self.cfg.media_data[content_type]['timescale'])))
                         media_template = seg_template.attrib['media']
                         media_template = media_template.replace('$Number$', 't$Time$')
                         seg_template.set('media', media_template)


### PR DESCRIPTION
Assuming the presentationTimeOffset in the period data uses timescale 1, this rescales the presentationTimeOffset when used in a SegmentTemplate with a different timescale.

Fixes issue #46