### PR TITLE
Added support for thumbnails.

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -209,7 +209,7 @@ class VodConfig(object):
         self.nr_segments_in_loop = 0
         self.segment_duration_s = 0
         self.default_tsbd_secs = DEFAULT_TIMESHIFT_BUFFER_DEPTH_IN_SECS
-        self.possible_media = ('video', 'audio', 'subtitles')
+        self.possible_media = ('video', 'audio', 'subtitles', 'image')
         self.media_data = {}
 
     def read_config(self, config_file):


### PR DESCRIPTION
 They must have extension .jpg, be declared in the config file and have the same numbering as the segments.

The config file should have a new section

[image]
representations = thumbs
timescale = 1

where representations is a comma-separate list of names of representations as for other media.
The timescale is not used since this is the internal timescale used in the segments, and there is none for jpeg images.