### PR TITLE
New feature- Segment loss scenarios for main live - deployment scenario IOP 4.2 section 4.11.4.3

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -105,6 +105,8 @@ class Config(object):
         self.stop_time = None
         self.timeoffset = None
         self.insert_sidx = False
+        self.segtimelineloss= False #This flag is true only when there is /segtimelineloss_1/
+        self.emsg_last_seg=False
 
     def __str__(self):
         lines = ["%s=%s" % (k, v) for (k, v) in self.__dict__.items() if not k.startswith("_")]
@@ -338,7 +340,7 @@ class ConfigProcessor(object):
                     "cont", "periods", "xlink", "etp", "etpDuration",
                     "insertad", "mpdcallback", "continuous", "segtimeline",
                     "segtimelinenr", "baseurl", "peroff", "scte35", "utc",
-                    "snr", "ato", "spd", "sidx")
+                    "snr", "ato", "spd", "sidx", "segtimelineloss")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -370,7 +372,8 @@ class ConfigProcessor(object):
                'urls' : self.cfg.multi_url,
                'periodOffset' : self.cfg.period_offset,
                'publishTime' : self.cfg.publish_time,
-               'mediaData' : self.cfg.media_data}
+               'mediaData' : self.cfg.media_data,
+               'segtimelineloss'  : self.cfg.segtimelineloss}
         if self.cfg.availability_end_time:
             mpd['availabilityEndTime'] = self.cfg.availability_end_time
         return mpd
@@ -464,6 +467,9 @@ class ConfigProcessor(object):
             elif key == "sidx":  # Insert sidx
                 if int(value) == 1:
                     cfg.insert_sidx = True
+            elif key == "segtimelineloss":  # If segment timeline loss case signalled.
+                if int(value) == 1:
+                    cfg.segtimelineloss = True
             else:
                 raise ConfigProcessorError("Cannot interpret option %s properly" % key)
             url_pos += 1

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -393,8 +393,8 @@ class DashProvider(object):
                     if a_var[0] == 'u' and b_var[0] == 'd':  # parse server up or down information
                         for i in range(num_loop):
                             if i * total_dur + dur1 < now_mod_60 <= (i + 1) * total_dur:
-                                    response = self.error_response("BaseURL server down at %d" % (self.now))
-                                    break
+                                response = self.error_response("BaseURL server down at %d" % (self.now))
+                                break
                             elif now_mod_60 == i* total_dur +dur1:     #Just before down time starts, add emsg box to the segment.
                                 cfg.emsg_last_seg=True
                                 response = self.process_media_segment(cfg, self.now_float)

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -335,6 +335,28 @@ class DashProvider(object):
                 raise Exception("Insert ad option can only be used in conjuction with the xlink option. To use the "
                                 "insert ad option, also set use xlink_m in your url.")
             response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
+            #The following 'if' is for IOP 4.11.4.3 , deployment scenario when segments not found.
+            if len(cfg.multi_url) > 0 and cfg.segtimelineloss == True:  # There is one specific baseURL with losses specified
+                    a_var, b_var = cfg.multi_url[0].split("_")
+                    dur1 = int(a_var[1:])
+                    dur2 = int(b_var[1:])
+                    total_dur = dur1 + dur2
+                    num_loop = int(ceil(60.0 / (float(total_dur))))
+                    now_mod_60 = self.now % 60
+                    if a_var[0] == 'u' and b_var[0] == 'd':  # parse server up or down information
+                        for i in range(num_loop):
+                            if i * total_dur + dur1 < now_mod_60 <= (i + 1) * total_dur:
+                                #Generate and provide mpd with the latest up time, so that last generated segment is shown
+                                #and no new S element added to SegmentTimeline.
+                                latestUptime= self.now - now_mod_60 + (i * total_dur + dur1)
+                                response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, latestUptime)
+                                break
+                            elif now_mod_60 == i* total_dur +dur1:
+                                #Just before down time starts, add InbandEventStream to the MPD.
+                                cfg.emsg_last_seg=True
+                                response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
+                                cfg.emsg_last_seg=False
+                           
             if nr_xlink_periods_per_hour > 0:
                 response = generate_response_with_xlink(response, cfg.ext, cfg.filename, nr_periods_per_hour,
                                                         nr_xlink_periods_per_hour, mpd_input_data['insertAd'])
@@ -371,8 +393,12 @@ class DashProvider(object):
                     if a_var[0] == 'u' and b_var[0] == 'd':  # parse server up or down information
                         for i in range(num_loop):
                             if i * total_dur + dur1 < now_mod_60 <= (i + 1) * total_dur:
-                                response = self.error_response("BaseURL server down at %d" % (self.now))
-                                break
+                                    response = self.error_response("BaseURL server down at %d" % (self.now))
+                                    break
+                            elif now_mod_60 == i* total_dur +dur1:     #Just before down time starts, add emsg box to the segment.
+                                cfg.emsg_last_seg=True
+                                response = self.process_media_segment(cfg, self.now_float)
+                                cfg.emsg_last_seg=False
                     elif a_var[0] == 'd' and b_var[0] == 'u':
                         for i in range(num_loop):
                             if i * (total_dur) < now_mod_60 <= i * (total_dur) + dur1:
@@ -532,7 +558,7 @@ class DashProvider(object):
         seg_filter = MediaSegmentFilter(media_seg_file, seg_nr, cfg.seg_duration, offset_at_loop_start, lmsg, timescale,
                                         scte35_per_minute, rel_path,
                                         is_ttml,
-                                        insert_sidx=cfg.insert_sidx)
+                                        insert_sidx=cfg.insert_sidx,emsg_last_seg=cfg.emsg_last_seg)
         seg_content = seg_filter.filter()
         self.new_tfdt_value = seg_filter.get_tfdt_value()
         return seg_content

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -558,7 +558,7 @@ class DashProvider(object):
         seg_filter = MediaSegmentFilter(media_seg_file, seg_nr, cfg.seg_duration, offset_at_loop_start, lmsg, timescale,
                                         scte35_per_minute, rel_path,
                                         is_ttml,
-                                        insert_sidx=cfg.insert_sidx,emsg_last_seg=cfg.emsg_last_seg)
+                                        insert_sidx=cfg.insert_sidx,emsg_last_seg=cfg.emsg_last_seg,now=self.now)
         seg_content = seg_filter.filter()
         self.new_tfdt_value = seg_filter.get_tfdt_value()
         return seg_content

--- a/dashlivesim/dashlib/mediasegmentfilter.py
+++ b/dashlivesim/dashlib/mediasegmentfilter.py
@@ -34,6 +34,7 @@ from . import scte35
 from .mp4filter import MP4Filter
 from .structops import str_to_uint32, uint32_to_str, str_to_uint64, uint64_to_str, str_to_sint32, sint32_to_str
 from .ttml_timing_offset import adjust_ttml_content
+from timeformatconversions import make_timestamp
 
 KEEP_SIDX = False
 
@@ -49,7 +50,7 @@ class MediaSegmentFilter(MP4Filter):
     #pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(self, file_name, seg_nr=None, seg_duration=1, offset=0, lmsg=False, track_timescale=None,
                  scte35_per_minute=0, rel_path=None, is_ttml=False,
-                 default_sample_duration=None, insert_sidx=False, emsg_last_seg=False):
+                 default_sample_duration=None, insert_sidx=False, emsg_last_seg=False , now=False):
         MP4Filter.__init__(self, file_name)
         self.top_level_boxes_to_parse = ["styp", "sidx", "moof", "mdat"]
         self.composite_boxes_to_parse = ['moof', 'traf']
@@ -68,6 +69,7 @@ class MediaSegmentFilter(MP4Filter):
         self.is_ttml = is_ttml
         self.ttml_size = None
         self.emsg_last_seg= emsg_last_seg
+        self.now=now
         if self.is_ttml:
             self.data = self.find_and_process_mdat(self.data)
 
@@ -373,6 +375,7 @@ class MediaSegmentFilter(MP4Filter):
         return uint32_to_str(out_size) + 'mdat' + ttml_out
 
     def create_emsg(self):
-        emsg_box=emsg.create_emsg(scheme_id_uri="urn:mpeg:dash:event:2012", value="", timescale=1, 
-                                  presentation_time_delta=0, event_duration=0, emsg_id=0, message_data="");
-        return emsg_box;
+        emsg_box=emsg.create_emsg(scheme_id_uri="urn:mpeg:dash:event:2012", value="1", timescale=1, 
+                                  presentation_time_delta=2, event_duration=0, emsg_id=0,
+                                  message_data=make_timestamp(self.now))
+        return emsg_box

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -327,7 +327,7 @@ class MpdProcessor(object):
                             end_time = min(now, self.cfg.stop_time)
                             use_closest = True
                         seg_timeline = segtime_gen.create_segtimeline(
-                                start_time, end_time, use_closest)
+                            start_time, end_time, use_closest)
                         remove_attribs(seg_template, ['duration'])
                         seg_template.set('timescale', str(self.cfg.media_data[content_type]['timescale']))
                         if pto != "0" and not offset_at_period_level:

--- a/dashlivesim/tests/test_segmentloss_mainlive.py
+++ b/dashlivesim/tests/test_segmentloss_mainlive.py
@@ -1,0 +1,110 @@
+# The copyright in this software is being made available under the BSD License,
+# included below. This software may be subject to other third party and contributor
+# rights, including patent rights, and no such rights are granted under this license.
+#
+# Copyright (c) 2015, Dash Industry Forum.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright notice, this
+#  list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#  this list of conditions and the following disclaimer in the documentation and/or
+#  other materials provided with the distribution.
+#  * Neither the name of Dash Industry Forum nor the names of its
+#  contributors may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND ANY
+#  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+#  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+#  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+#  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+#  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from dash_test_util import *
+from dashlivesim.dashlib import dash_proxy
+from dashlivesim.dashlib import mpdprocessor
+
+def isEmsgPresentInSegment(data):
+    "Check if emsg box is present in segment."
+    return data.find("emsg")>=0
+
+class TestSegTimelineLossMainLive(unittest.TestCase):
+    "Test of Segment timeline loss signalling in MPD and segments for main live case"
+    #def setUp(self):
+    #   self.oldBaseUrlState = mpdprocessor.SET_BASEURL
+    #   mpdprocessor.SET_BASEURL = True
+
+    #def tearDown(self):
+    #   mpdprocessor.SET_BASEURL = self.oldBaseUrlState
+        
+    def testNoInbandStreamElemInMPD(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=60)
+        d = dp.handle_request()
+        inbandEventElement = d.find('<InbandEventStream')
+        self.assertLess(inbandEventElement, 0)
+    
+    def testInbandStreamElemInMPD(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10)
+        d = dp.handle_request()
+        inbandEventElement = d.find("<InbandEventStream")
+        self.assertGreater(inbandEventElement, 0)
+    
+    def testNoEmsgInSegment(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'A1', '0.m4s']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=60)
+        d = dp.handle_request()
+        self.assertFalse(isEmsgPresentInSegment(d))
+       
+    def testEmsgInSegment(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'A1', '0.m4s']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10)
+        d = dp.handle_request()
+        self.assertTrue(isEmsgPresentInSegment(d))
+    
+    def testNoNewSegmentsAdded(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10)
+        d = dp.handle_request()     
+        start=d.find('<SegmentTimeline>')
+        end=d.find('</SegmentTimeline>')
+        testOutputFile = "SegTimeline1.txt"
+        segTimeline=d[start:end+18]
+        write_data_to_outfile(d[start:end+18], testOutputFile)
+        dp2 = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=15)
+        d2 = dp2.handle_request()
+        start2=d2.find('<SegmentTimeline>')
+        end2=d2.find('</SegmentTimeline>')
+        testOutputFile = "SegTimeline2.txt"
+        segTimeline2=d2[start2:end2+18]
+        write_data_to_outfile(d2[start2:end2+18], testOutputFile)
+        self.assertEqual(segTimeline, segTimeline2)
+        
+    def testNewSegmentsAdded(self):
+        urlParts = ['livesim', 'baseurl_u10_d20', 'segtimeline_1', 'segtimelineloss_1', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=10)
+        d = dp.handle_request()
+        start=d.find('<SegmentTimeline>')
+        end=d.find('</SegmentTimeline>')
+        testOutputFile = "SegTimeline3.txt"
+        write_data_to_outfile(d[start:end+18], testOutputFile)
+        segTimeline=d[start:end+18]
+        dp2 = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=31)
+        d2 = dp2.handle_request()
+        start2=d2.find('<SegmentTimeline>')
+        end2=d2.find('</SegmentTimeline>')
+        testOutputFile = "SegTimeline4.txt"
+        write_data_to_outfile(d2[start2:end2+18], testOutputFile)
+        segTimeline2=d2[start2:end2+18]
+        self.assertNotEqual(segTimeline, segTimeline2)
+        


### PR DESCRIPTION
This PR is for the simulation of IOP section 4.11.4.3 for the case of encoder not generating next segment. 
In the implementation, up/down feature of baseurl is used to simulate the non availability of segments. Additionally new url key "segtimelineloss_1" is used to invoke the new functionality (explained below).

IOP guidelines and respective implementations are as follows

1. From IOP, when an encoder fails for one or more specific Representations to generate the next segment, then the DASH packager , adds emsg to the last generated segment. The MPD validity expiration is set to the duration of the current segment or smaller. (Implementation: Emsg box added to the last segment of the UP interval and the fields of emsg are as according to section 5.10.4.2 DASH standard.) 

2. The emsg shall be added to all Representations that announce that they carry the message as an inband stream. (Implementation: InbandEventStream added in MPD for all reps)

3. The MPD is updated on the server such that the last generated segment is documented in the Segment timeline and no new S element is added to the timeline. (Implementation: no new S element added in the Down interval).

4. Only after the Representation(s) under loss resumes, a new S element is written with S@t matching the earliest presentation time of the newly generated Segment. The DASH client with it next update will resume and possibly take into account again this Representation. (Implementation: As the next UP interval begins, new S elements added).

Sample URL : livesim-dev/baseurl_u10_d20/segtimeline_1/segtimelineloss_1/testpic_2s/Manifest.mpd

Unit tests are performed and added as well.