### PR TITLE
4th Edition AMD1 MPD Patch Update Implementation

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -66,7 +66,7 @@ class Config(object):
         self.media_presentation_duration = None
         self.timeshift_buffer_depth_in_s = None
         self.minimum_update_period_in_s = None
-        self.modulo_period = None
+        self.modulo_period = False # True if modulo behavior active
         self.last_segment_numbers = [] # The last segment number in every period.
         self.init_seg_avail_offset = 0 # The number of secs before AST that one can fetch the init segments
         self.tfdt32_flag = False # Restart every 3 hours make tfdt fit into 32 bits.
@@ -430,6 +430,7 @@ class ConfigProcessor(object):
                 cfg.minimum_update_period_in_s = int(value)
             elif key == "modulo": # Make a number of time-limited sessions every hour
                 modulo_period = ModuloPeriod(int(value), now_int)
+                cfg.modulo_period = True
             elif key == "tfdt": # Use 32-bit tfdt (which means that AST must be more recent as well)
                 cfg.tfdt32_flag = True
             elif key == "cont": # Continuous update of MPD AST and seg_nr.

--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -107,6 +107,8 @@ class Config(object):
         self.insert_sidx = False
         self.segtimelineloss= False #This flag is true only when there is /segtimelineloss_1/
         self.emsg_last_seg=False
+        self.patching = False # This flag is only true when there is /patching_1/ in the URL
+        self.patch_base = -1
 
     def __str__(self):
         lines = ["%s=%s" % (k, v) for (k, v) in self.__dict__.items() if not k.startswith("_")]
@@ -341,7 +343,7 @@ class ConfigProcessor(object):
                     "insertad", "mpdcallback", "continuous", "segtimeline",
                     "segtimelinenr", "baseurl", "peroff", "scte35", "utc",
                     "snr", "ato", "spd", "sidx", "segtimelineloss",
-                    "sts", "sid")
+                    "sts", "sid", "patching", "patch")
 
     def __init__(self, vod_cfg_dir, base_url):
         self.vod_cfg_dir = vod_cfg_dir
@@ -374,7 +376,9 @@ class ConfigProcessor(object):
                'periodOffset' : self.cfg.period_offset,
                'publishTime' : self.cfg.publish_time,
                'mediaData' : self.cfg.media_data,
-               'segtimelineloss'  : self.cfg.segtimelineloss}
+               'segtimelineloss'  : self.cfg.segtimelineloss,
+               'patching': self.cfg.patching,
+               'originalPublishTime': self.cfg.patch_base}
         if self.cfg.availability_end_time:
             mpd['availabilityEndTime'] = self.cfg.availability_end_time
         return mpd
@@ -478,6 +482,12 @@ class ConfigProcessor(object):
             elif key == "segtimelineloss":  # If segment timeline loss case signalled.
                 if int(value) == 1:
                     cfg.segtimelineloss = True
+            elif key == "patching":
+                if int(value) == 1: # Only valid when it's set to 1
+                    cfg.patching = True
+            elif key == "patch":
+                cfg.patch_base = int(value)
+                cfg.patching = True # patch base will imply patching
             else:
                 raise ConfigProcessorError("Cannot interpret option %s properly" % key)
             url_pos += 1

--- a/dashlivesim/dashlib/dash_namespace.py
+++ b/dashlivesim/dashlib/dash_namespace.py
@@ -32,9 +32,14 @@ import re
 
 RE_NAMESPACE_TAG = re.compile(r"({.*})?(.*)")
 DASH_NAMESPACE = "{urn:mpeg:dash:schema:mpd:2011}"
-
+DASH_PATCH_NAMESPACE = "{urn:mpeg:dash:schema:mpd-patch:2020}"
 
 def add_ns(element):
     "Add DASH namespace to element or to path."
     parts = element.split('/')
     return "/".join([DASH_NAMESPACE + e for e in parts])
+
+def add_patch_ns(element):
+    """Add Patch namespace to element or to path."""
+    parts = element.split('/')
+    return "/".join([DASH_PATCH_NAMESPACE + e for e in parts])

--- a/dashlivesim/dashlib/dash_proxy.py
+++ b/dashlivesim/dashlib/dash_proxy.py
@@ -336,6 +336,20 @@ class DashProvider(object):
             if mpd_input_data['insertAd'] > 0 and nr_xlink_periods_per_hour < 0:
                 raise Exception("Insert ad option can only be used in conjuction with the xlink option. To use the "
                                 "insert ad option, also set use xlink_m in your url.")
+
+            # based on simulator implementation there are a few option combinations with patching that have not
+            # been directly implemented, implementation can be requested with a github issue but we would prefer
+            # the scenario fail than improperly work
+            if mpd_input_data['patching']:
+                base_text = "The patching option cannot be used in conjunction with the %s option currently, please file a github issue to request implementation."
+                if nr_xlink_periods_per_hour != -1:
+                    raise Exception(base_text % "xlink")
+                if cfg.segtimelineloss:
+                    raise Exception(base_text % "segtimelineloss")
+                print cfg.modulo_period
+                if cfg.modulo_period:
+                    raise Exception(base_text % "modulo")
+
             response = self.generate_dynamic_mpd(cfg, mpd_filename, mpd_input_data, self.now)
             #The following 'if' is for IOP 4.11.4.3 , deployment scenario when segments not found.
             if len(cfg.multi_url) > 0 and cfg.segtimelineloss == True:  # There is one specific baseURL with losses specified

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -237,7 +237,7 @@ class MpdProcessor(object):
         # Insert patch location update node
         patch_location = re.sub(r"/patch_[-\d]+", "/patch_%d" % 
                                 self.mpd_proc_cfg['now'], self.full_url)
-        patch_replace = patch_ops.insert_replace_op(patch, '/MPD/PatchLocation[1]')
+        patch_replace = patch_ops.insert_replace_op(patch, '/MPD/PatchLocation[0]')
         self.insert_patch_location(patch_replace, 0, patch_location)
 
         # For this simulator we assume patches will not be announcing new high level structures
@@ -260,7 +260,7 @@ class MpdProcessor(object):
                 self.update_period(mpd, period, pdata, last_period_id, mpd_data['periodOffset'] >= 0, segtimeline_generators)
 
                 # create the actual insertion operation
-                period_add = patch_ops.insert_add_op(patch, '/MPD')
+                period_add = patch_ops.insert_add_op(patch, '/MPD', 'append')
                 period_add.append(period)
 
             elif segtimeline_generators:
@@ -282,7 +282,7 @@ class MpdProcessor(object):
                         s_elems = seg_timeline.getchildren()
                         if len(s_elems) > 0:
                             timeline_location = "/MPD/Period[@id='%s']/AdaptationSet[@id='%s']/SegmentTemplate/SegmentTimeline" % (pdata.get('id'), ad_set.get('id'))
-                            timeline_add = patch_ops.insert_add_op(patch, timeline_location)
+                            timeline_add = patch_ops.insert_add_op(patch, timeline_location, 'append')
                             timeline_add.extend(s_elems)
 
             last_period_id = pdata.get('id')

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -466,10 +466,12 @@ class MpdProcessor(object):
         return elem
 
     def update_proxy_url_parameters(self, loc_url, include_patch_base=False):
-        loc_url = re.sub(r"/startrel_[-\d]+", "/start_%d" %
-                         self.cfg.start_time, loc_url)
-        loc_url = re.sub(r"/stoprel_[-\d]+", "/stop_%d" %
-                         self.cfg.stop_time, loc_url)
+        if self.cfg.start_time:
+            loc_url = re.sub(r"/startrel_[-\d]+", "/start_%d" %
+                             self.cfg.start_time, loc_url)
+        if self.cfg.stop_time:
+            loc_url = re.sub(r"/stoprel_[-\d]+", "/stop_%d" %
+                             self.cfg.stop_time, loc_url)
         if include_patch_base:
             loc_url = re.sub(r"/patching_[-\d]+", "/patch_%d" %
                              self.mpd_proc_cfg['now'], loc_url)

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -473,6 +473,8 @@ class MpdProcessor(object):
             loc_url = re.sub(r"/stoprel_[-\d]+", "/stop_%d" %
                              self.cfg.stop_time, loc_url)
         if include_patch_base:
+            loc_url = re.sub(r"/patch_[-\d]+", "/patch_%d" %
+                             self.mpd_proc_cfg['now'], loc_url)
             loc_url = re.sub(r"/patching_[-\d]+", "/patch_%d" %
                              self.mpd_proc_cfg['now'], loc_url)
         return loc_url

--- a/dashlivesim/dashlib/patch_ops.py
+++ b/dashlivesim/dashlib/patch_ops.py
@@ -1,3 +1,4 @@
+# Generates nodes conformant with DASH restricted form of https://tools.ietf.org/html/rfc5261
 from xml.etree import ElementTree
 PATCH_OP_NAMESPACE = "{urn:ietf:params:xml:schema:patch-ops}"
 
@@ -19,3 +20,11 @@ def insert_add_op(target, selector, pos):
     add_elem.set('pos', pos)
     target.append(add_elem)
     return add_elem
+
+def insert_remove_op(target, selector):
+    remove_elem = ElementTree.Element(add_ns('remove'))
+    remove_elem.tail = "\n"
+    remove_elem.set('sel', selector)
+    # ws attribute omitted as it is not critical to MPDs
+    target.append(remove_elem)
+    return remove_elem

--- a/dashlivesim/dashlib/patch_ops.py
+++ b/dashlivesim/dashlib/patch_ops.py
@@ -12,7 +12,7 @@ def insert_replace_op(target, selector):
     target.append(replace_elem)
     return replace_elem
 
-def insert_add_op(target, selector, pos="after"):
+def insert_add_op(target, selector, pos):
     add_elem = ElementTree.Element(add_ns('add'))
     add_elem.tail = "\n"
     add_elem.set('sel', selector)

--- a/dashlivesim/dashlib/patch_ops.py
+++ b/dashlivesim/dashlib/patch_ops.py
@@ -1,0 +1,21 @@
+from xml.etree import ElementTree
+PATCH_OP_NAMESPACE = "{urn:ietf:params:xml:schema:patch-ops}"
+
+def add_ns(element):
+    parts = element.split('/')
+    return "/".join([PATCH_OP_NAMESPACE + e for e in parts])
+
+def insert_replace_op(target, selector):
+    replace_elem = ElementTree.Element(add_ns('replace'))
+    replace_elem.tail = "\n"
+    replace_elem.set('sel', selector)
+    target.append(replace_elem)
+    return replace_elem
+
+def insert_add_op(target, selector, pos="after"):
+    add_elem = ElementTree.Element(add_ns('add'))
+    add_elem.tail = "\n"
+    add_elem.set('sel', selector)
+    add_elem.set('pos', pos)
+    target.append(add_elem)
+    return add_elem

--- a/dashlivesim/dashlib/segtimeline.py
+++ b/dashlivesim/dashlib/segtimeline.py
@@ -170,7 +170,7 @@ class SegmentTimeLineGenerator(object):
         seg_data = self.segtimedata[index]
         repeats = 0
         accumulated_end_time = seg_data.start_time + seg_data.duration
-        while accumulated_end_time < rel_time:
+        while accumulated_end_time <= rel_time:
             accumulated_end_time += seg_data.duration
             repeats += 1
         return index, repeats, nr_wraps


### PR DESCRIPTION
This is an initial pass at bringing in support for the MPD Patching mechanism as outlined in the 4th Edition AMD1 text. This defines a new boolean parameter `patching` which when provided causes the generated MPD to contain the appropriate `PatchLocation` element and have subsequent updates from the `PatchLocation` provided as valid MPD Patch responses.

To accomplish the actual patch responses a second parameter is introduced, `patch`, which is set to the base time of the patch that will be produced. This parameter is set as part of the URI provided in the `PatchLocation` element and is not expected to be set manually.

Looking for feedback on approach, I still need to update with new unit test cases