### PR TITLE
Implementation of low-latency compliance

### DIFF
--- a/dashlivesim/dashlib/configprocessor.py
+++ b/dashlivesim/dashlib/configprocessor.py
@@ -483,9 +483,10 @@ class ConfigProcessor(object):
             elif key == "chunkdur":   # Chunkdur
                 try:
                     chunk_duration = float(value)
-                    if 0.0 < chunk_duration:
+                    if chunk_duration > 0:
                         cfg.chunk_duration_in_s = chunk_duration
                         cfg.availability_time_complete = False
+                        print(cfg.chunk_duration_in_s)
                 except ValueError:
                     pass
             else:

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -254,6 +254,19 @@ class MpdProcessor(object):
         sd_elem.tail = "\n"
         mpd.insert(pos, sd_elem)
 
+    def insert_producer_reference(self, ad_set, pos):
+        prt_elem = ElementTree.Element(add_ns('ProducerReferenceTime'))
+        prt_elem.set("id", "0")
+        prt_elem.set("type", "encoder")
+        prt_elem.set("wallClockTime", "1970-01-01T00:00:00")
+        prt_elem.set("presentationTime", "0")
+        utc_elem = self.create_descriptor_elem('UTCTiming', 'urn:mpeg:dash:utc:http-iso:2014',
+                                               UTC_TIMING_HTTP_SERVER)
+        prt_elem.insert(0, utc_elem)
+        prt_elem.text = "\n"
+        prt_elem.tail = "\n"
+        ad_set.insert(pos, prt_elem)
+
     def update_periods(self, mpd, period_data, offset_at_period_level, ll_data):
         "Update periods to provide appropriate values."
         # pylint: disable = too-many-statements
@@ -341,6 +354,8 @@ class MpdProcessor(object):
                                                                         "urn:mpeg:dash:period_continuity:2014",
                                                                         last_period_id)
                     ad_set.insert(ad_pos, supplementalprop_elem)
+                if ll_data:
+                    self.insert_producer_reference(ad_set, ad_pos)
                 seg_templates = ad_set.findall(add_ns('SegmentTemplate'))
                 for seg_template in seg_templates:
                     set_attribs(seg_template, segmenttemplate_attribs, pdata)

--- a/dashlivesim/dashlib/mpdprocessor.py
+++ b/dashlivesim/dashlib/mpdprocessor.py
@@ -107,6 +107,13 @@ class MpdProcessor(object):
             if old_profiles.find("dash-if-simple") >= 0:
                 new_profiles = old_profiles.replace("dash-if-simple", "dash-if-main")
                 mpd.set('profiles', new_profiles)
+        if 'add_profiles' in mpd_data:
+            profiles = mpd.get('profiles').split(",")
+            for prof in mpd_data['add_profiles']:
+                if prof not in profiles:
+                    profiles.append(prof)
+            mpd.set('profiles', ",".join(profiles))
+
         key_list = ['availabilityStartTime', 'availabilityEndTime', 'timeShiftBufferDepth',
                     'minimumUpdatePeriod', 'maxSegmentDuration',
                     'mediaPresentationDuration', 'suggestedPresentationDelay']

--- a/dashlivesim/tests/test_lowlatency.py
+++ b/dashlivesim/tests/test_lowlatency.py
@@ -20,7 +20,7 @@ class TestLowLatencyMPD(unittest.TestCase):
         urlParts = ['livesim', 'chunkdur_1', 'ato_7', 'testpic', 'Manifest.mpd']
         dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=0)
         d = mpd_proxy.get_mpd(dp)
-        print(d)
+        #print(d)
         self.assertTrue(d.find('UTCTiming') > 0,
                         "Should find UTC-timing element")
         self.assertTrue(d.find('http://www.dashif.org/guidelines/low-latency-live-v5') > 0,
@@ -31,3 +31,5 @@ class TestLowLatencyMPD(unittest.TestCase):
                         "Should find availabilityTimeComplete in SegmentTemplate")
         self.assertTrue(d.find('<ServiceDescription') > 0,
                         "Should find ServiceDescription in MPD")
+        self.assertTrue(d.find('<ProducerReferenceTime') > 0,
+                        "Should find ProducerReferenceTime in MPD")

--- a/dashlivesim/tests/test_lowlatency.py
+++ b/dashlivesim/tests/test_lowlatency.py
@@ -1,0 +1,31 @@
+import unittest
+
+from dashlivesim.tests.dash_test_util import VOD_CONFIG_DIR, CONTENT_ROOT
+from dashlivesim.dashlib import mpd_proxy, dash_proxy
+from dashlivesim.dashlib import mpdprocessor
+
+
+class TestLowLatencyMPD(unittest.TestCase):
+    "Test that low-latency MPD has the right attributes"
+
+    def setUp(self):
+        self.oldBaseUrlState = mpdprocessor.SET_BASEURL
+        mpdprocessor.SET_BASEURL = False
+
+    def tearDown(self):
+        mpdprocessor.SET_BASEURL = self.oldBaseUrlState
+
+    def testCorrectFieldsInMPD(self):
+        mpdprocessor.SET_BASEURL = True
+        urlParts = ['livesim', 'chunkdur_1', 'ato_7', 'testpic', 'Manifest.mpd']
+        dp = dash_proxy.DashProvider("streamtest.eu", urlParts, None, VOD_CONFIG_DIR, CONTENT_ROOT, now=0)
+        d = mpd_proxy.get_mpd(dp)
+        print(d)
+        self.assertTrue(d.find('UTCTiming') > 0,
+                        "Should find UTC-timing element")
+        self.assertTrue(d.find('http://www.dashif.org/guidelines/low-latency-live-v5') > 0,
+                        "Should find low-latency profile")
+        self.assertTrue(d.find("<BaseURL>http://streamtest.eu/livesim/chunkdur_1/ato_7/testpic/</BaseURL>") > 0,
+                        "Should not have availabilityTimeComplete here")
+        self.assertTrue(d.find('availabilityTimeComplete="false" availabilityTimeOffset="7.000000"') > 0,
+                        "Should find availabilityTimeComplete in ")

--- a/dashlivesim/tests/test_lowlatency.py
+++ b/dashlivesim/tests/test_lowlatency.py
@@ -28,4 +28,6 @@ class TestLowLatencyMPD(unittest.TestCase):
         self.assertTrue(d.find("<BaseURL>http://streamtest.eu/livesim/chunkdur_1/ato_7/testpic/</BaseURL>") > 0,
                         "Should not have availabilityTimeComplete here")
         self.assertTrue(d.find('availabilityTimeComplete="false" availabilityTimeOffset="7.000000"') > 0,
-                        "Should find availabilityTimeComplete in ")
+                        "Should find availabilityTimeComplete in SegmentTemplate")
+        self.assertTrue(d.find('<ServiceDescription') > 0,
+                        "Should find ServiceDescription in MPD")


### PR DESCRIPTION
As chunkier is specified in the URL, the live-simulator should go into low-latency mode and add low-latency information to the MPD and chunk the segments.

New elements in the MPD are
a new profile in mod
ServiceDescription@MPD
ProducerReferenceTime@AdaptationSet
availabilityTimeComplete and availabilityTimeOffset moved to SegmentTemplate